### PR TITLE
initial support for creating and sending nested bundles

### DIFF
--- a/lo/lo_lowlevel.h
+++ b/lo/lo_lowlevel.h
@@ -475,6 +475,16 @@ lo_bundle lo_bundle_new(lo_timetag tt);
 int lo_bundle_add_message(lo_bundle b, const char *path, lo_message m);
 
 /**
+ * \brief  Adds an OSC bundle to an existing bundle.
+ *
+ * The child bundle passed is appended to the list of child bundles|messages in the parent bundle to be
+ * dispatched.
+ *
+ * \return 0 if successful, less than 0 otherwise.
+ */
+int lo_bundle_add_bundle(lo_bundle b, lo_bundle n);
+
+/**
  * \brief  Return the length of a bundle in bytes.
  *
  * Includes the marker and typetage length.
@@ -489,6 +499,24 @@ size_t lo_bundle_length(lo_bundle b);
  * \param b The bundle to be counted.
  */
 unsigned int lo_bundle_count(lo_bundle b);
+
+/**
+ * \brief  Gets the element type contained within a bundle.
+ *
+ * Returns a lo_element_type at a given index within a bundle.
+
+ * \return The requested lo_element_type if successful, otherwise 0.
+ */
+lo_element_type lo_bundle_get_type(lo_bundle b, int index);
+
+/**
+ * \brief  Gets a nested bundle contained within a bundle.
+ *
+ * Returns a lo_bundle at a given index within a bundle.
+ *
+ * \return The requested lo_bundle if successful, otherwise 0.
+ */
+lo_bundle lo_bundle_get_bundle(lo_bundle b, int index);
 
 /**
  * \brief  Gets a message contained within a bundle.
@@ -524,11 +552,12 @@ void *lo_bundle_serialise(lo_bundle b, void *to, size_t *size);
 void lo_bundle_free(lo_bundle b);
 
 /**
- * \brief  Frees the memory taken by a bundle object and messages in the bundle.
+ * \brief  Frees the memory taken by a bundle object and its messages and nested bundles recursively.
  *
- * \param b The bundle, which may contain messages, to be freed.
+ * \param b The bundle, which may contain messages and nested bundles, to be freed.
 */
-void lo_bundle_free_messages(lo_bundle b);
+void lo_bundle_free_recursive(lo_bundle b);
+#define lo_bundle_free_messages lo_bundle_free_recursive
 
 /**
  * \brief Return true if the type specified has a numerical value, such as

--- a/lo/lo_osc_types.h
+++ b/lo/lo_osc_types.h
@@ -52,6 +52,18 @@ typedef struct {
 } lo_timetag;
 
 /**
+ * \brief An enumeration of bundle element types liblo can handle.
+ *
+ * The element of a bundle can either be a message or an other bundle.
+ */
+typedef enum {
+	/** bundle element is a message */
+	LO_ELEMENT_MESSAGE = 1,
+	/** bundle element is a bundle */
+	LO_ELEMENT_BUNDLE = 2
+} lo_element_type;
+
+/**
  * \brief An enumeration of the OSC types liblo can send and receive.
  *
  * The value of the enumeration is the typechar used to tag messages and to

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -28,10 +28,124 @@ lo_bundle lo_bundle_new(lo_timetag tt)
     b->size = 4;
     b->len = 0;
     b->ts = tt;
-    b->msgs = calloc(b->size, sizeof(lo_message));
-    b->paths = calloc(b->size, sizeof(char *));
+    b->elmnts = calloc(b->size, sizeof(lo_element));
+    b->refcount = 0;
 
     return b;
+}
+
+static lo_bundle *push_to_list(lo_bundle *list, lo_bundle ptr, size_t *len, size_t *size)
+{
+    if (*len >= *size) {
+	*size *= 2;
+	list = realloc(list, *size * sizeof(lo_bundle));
+    }
+
+    list[*len] = ptr;
+    (*len)++;
+
+    return list;
+}
+
+static lo_bundle *pop_from_list(lo_bundle *list, size_t *len, size_t *size)
+{
+    (*len)--;
+    return list;
+}
+
+static int is_in_list(lo_bundle *list, lo_bundle ptr, size_t *len)
+{
+    size_t i;
+
+    for (i = 0; i < *len; i++)
+	if (list[i] == ptr)
+	    return -1;
+    
+    return 0;
+}
+
+static lo_bundle *walk_tree(lo_bundle *B, lo_bundle b, size_t *len, size_t *size, int *ret)
+{
+    size_t i;
+    int res;
+
+    // check whether bundle is part of parents list
+    if (is_in_list(B, b, len)) {
+	*ret = -1;
+	return B;
+    }
+
+    // push bundle to parents list
+    B = push_to_list(B, b, len, size);
+
+    res = 0;
+    for (i = 0; i < b->len; i++) {
+	if (b->elmnts[i].type == LO_ELEMENT_BUNDLE) {
+	    B = walk_tree(B, b->elmnts[i].content.bundle, len, size, &res);
+	    if (res)
+		break;
+	}
+    }
+
+    // pop bundle from parents list
+    B = pop_from_list(B, len, size);
+
+    *ret = res;
+    return B;
+}
+
+static int lo_bundle_circular(lo_bundle b)
+{
+    size_t len = 0;
+    size_t size = 4;
+    int res;
+    lo_bundle *B = calloc(size, sizeof(lo_bundle));
+
+    B = walk_tree(B, b, &len, &size, &res);
+
+    if (B)
+	free(B);
+
+    return res;
+}
+
+static int lo_bundle_add_element(lo_bundle b, int type, const char *path, void *elmnt)
+{
+    if (b->len >= b->size) {
+	b->size *= 2;
+	b->elmnts = realloc(b->elmnts, b->size * sizeof(lo_element));
+	if (!b->elmnts)
+	    return -1;
+    }
+
+    b->elmnts[b->len].type = type;
+
+    switch (type) {
+	case LO_ELEMENT_MESSAGE: {
+	    lo_message msg = elmnt;
+	    (msg->refcount)++;
+	    b->elmnts[b->len].content.message.msg = msg;
+	    b->elmnts[b->len].content.message.path = path;
+	    (b->len)++;
+	    break;
+	}
+	case LO_ELEMENT_BUNDLE: {
+	    lo_bundle bndl = elmnt;
+	    (bndl->refcount)++;
+	    b->elmnts[b->len].content.bundle = bndl;
+	    (b->len)++;
+
+	    // do not add bundle if a circular reference is found
+	    if (lo_bundle_circular(b)) {
+		(bndl->refcount)--;
+		(b->len)--;
+		return -1;
+	    }
+	    break;
+	}
+    }
+
+    return 0;
 }
 
 int lo_bundle_add_message(lo_bundle b, const char *path, lo_message m)
@@ -39,28 +153,40 @@ int lo_bundle_add_message(lo_bundle b, const char *path, lo_message m)
     if (!m)
         return 0;
 
-    if (b->len >= b->size) {
-        b->size *= 2;
-        b->msgs = realloc(b->msgs, b->size * sizeof(lo_message));
-        b->paths = realloc(b->paths, b->size * sizeof(char *));
-        if (!b->msgs || !b->paths)
-            return -1;
+    return lo_bundle_add_element (b, LO_ELEMENT_MESSAGE, path, m);
+}
+
+int lo_bundle_add_bundle(lo_bundle b, lo_bundle n)
+{
+    if (!n)
+	return 0;
+    
+    return lo_bundle_add_element (b, LO_ELEMENT_BUNDLE, NULL, n);
+}
+
+lo_element_type lo_bundle_get_type(lo_bundle b, int index)
+{
+    if (index < (int)b->len) {
+        return b->elmnts[index].type;
     }
+    return 0;
+}
 
-    b->msgs[b->len] = m;
-    b->paths[b->len] = (char *) path;
-
-    (b->len)++;
+lo_bundle lo_bundle_get_bundle(lo_bundle b, int index)
+{
+    if ( (index < (int)b->len) && (b->elmnts[index].type == LO_ELEMENT_BUNDLE) ) {
+        return b->elmnts[index].content.bundle;
+    }
     return 0;
 }
 
 lo_message lo_bundle_get_message(lo_bundle b, int index,
                                  const char **path)
 {
-    if (index < (int)b->len) {
+    if ( (index < (int)b->len) && (b->elmnts[index].type == LO_ELEMENT_MESSAGE) ) {
         if (path)
-            *path = b->paths[index];
-        return b->msgs[index];
+            *path = b->elmnts[index].content.message.path;
+        return b->elmnts[index].content.message.msg;
     }
     return 0;
 }
@@ -80,9 +206,15 @@ size_t lo_bundle_length(lo_bundle b)
     }
 
     size += b->len * 4;         /* sizes */
-    for (i = 0; i < b->len; i++) {
-        size += lo_message_length(b->msgs[i], b->paths[i]);
-    }
+    for (i = 0; i < b->len; i++)
+	switch (b->elmnts[i].type) {
+	    case LO_ELEMENT_BUNDLE:
+		size += lo_bundle_length(b->elmnts[i].content.bundle);
+		break;
+	    case LO_ELEMENT_MESSAGE:
+		size += lo_message_length(b->elmnts[i].content.message.msg, b->elmnts[i].content.message.path);
+		break;
+	}
 
     return size;
 }
@@ -120,17 +252,25 @@ void *lo_bundle_serialise(lo_bundle b, void *to, size_t * size)
     pos += 4;
 
     for (i = 0; i < b->len; i++) {
-        lo_message_serialise(b->msgs[i], b->paths[i], pos + 4, &skip);
-        bes = (int32_t *) (void *)pos;
-        *bes = lo_htoo32(skip);
-        pos += skip + 4;
+	switch (b->elmnts[i].type) {
+	    case LO_ELEMENT_MESSAGE:
+		lo_message_serialise(b->elmnts[i].content.message.msg, b->elmnts[i].content.message.path, pos + 4, &skip);
+		break;
+	    case LO_ELEMENT_BUNDLE:
+		lo_bundle_serialise(b->elmnts[i].content.bundle, pos+4, &skip);
+		break;
+	}
 
-        if (pos > (char *) to + s) {
+	bes = (int32_t *) (void *)pos;
+	*bes = lo_htoo32(skip);
+	pos += skip + 4;
+
+	if (pos > (char *) to + s) {
             fprintf(stderr, "liblo: data integrity error at message %lu\n",
                     (long unsigned int)i);
 
-            return NULL;
-        }
+	    return NULL;
+	}
     }
     if (pos != (char *) to + s) {
         fprintf(stderr, "liblo: data integrity error\n");
@@ -149,57 +289,109 @@ void lo_bundle_free(lo_bundle b)
         return;
     }
 
-    free(b->msgs);
-    free(b->paths);
+    free(b->elmnts);
     free(b);
 }
 
-static int _lo_internal_compare_ptrs(const void *a, const void *b)
-{
-    if (*(void **) a < *(void **) b)
-        return -1;
-    if (*(void **) a == *(void **) b)
-        return 0;
-    return 1;
-}
-
-void lo_bundle_free_messages(lo_bundle b)
+static void collect_element(lo_element *elmnt)
 {
     size_t i;
-    lo_message tmp = 0;
+
+    switch (elmnt->type) {
+	case LO_ELEMENT_MESSAGE: {
+	    lo_message msg = elmnt->content.message.msg;
+	    (msg->refcount)--;
+	    if (msg->refcount == 0)
+		lo_message_free(msg);
+	    break;
+	}
+
+	case LO_ELEMENT_BUNDLE: {
+	    lo_bundle bndl = elmnt->content.bundle;
+	    (bndl->refcount)--;
+	    if (bndl->refcount == 0) {
+		for (i = 0; i < bndl->len; i++)
+		    collect_element(&bndl->elmnts[i]);
+
+		free(bndl->elmnts);
+		free(bndl);
+	    }
+	    break;
+	}
+    }
+}
+
+void lo_bundle_free_recursive(lo_bundle b)
+{
+    size_t i;
 
     if (!b)
         return;
 
-    /* avoid freeing the same message twice */
-    if (b->len > 2)
-        qsort(b->msgs, b->len, sizeof(lo_message *),
-              _lo_internal_compare_ptrs);
+    for (i = 0; i < b->len; i++)
+	collect_element(&b->elmnts[i]);
 
-    for (i = 0; i < b->len; i++) {
-        if (b->msgs[i] != tmp) {
-            tmp = b->msgs[i];
-            lo_message_free(b->msgs[i]);
-        }
-    }
-    free(b->msgs);
-    free(b->paths);
+    free(b->elmnts);
     free(b);
+}
+
+static void offset_pp(int offset, int *state)
+{
+    size_t i;
+
+    for (i=0; i < offset; i++) {
+	if (!state[i])
+	    printf("│        ");
+	else // last
+	    printf("         ");
+    }
+
+    if (!state[offset])
+	printf("├─");
+    else // last
+	printf("└─");
+}
+
+static int *lo_bundle_pp_internal(lo_bundle b, int offset, int *state, size_t *len)
+{
+    size_t i;
+   
+    if (offset+2 > *len) {
+	*len *= 2;
+	state = realloc(state, *len*sizeof(int));
+    }
+
+    offset_pp(offset, state);
+    printf("bundle─┬─(%08x.%08x)\n", b->ts.sec, b->ts.frac);
+    for (i = 0; i < b->len; i++) {
+	state[offset+1] = i != b->len-1 ? 0 : 1;
+
+	switch(b->elmnts[i].type) {
+	    case LO_ELEMENT_MESSAGE:
+		offset_pp(offset+1, state);
+		printf("%s ", b->elmnts[i].content.message.path);
+		lo_message_pp(b->elmnts[i].content.message.msg);
+		break;
+	    case LO_ELEMENT_BUNDLE:
+		state = lo_bundle_pp_internal(b->elmnts[i].content.bundle, offset+1, state, len);
+		break;
+	}
+    }
+
+    return state;
 }
 
 void lo_bundle_pp(lo_bundle b)
 {
-    size_t i;
-
     if (!b)
         return;
 
-    printf("bundle(%f):\n",
-           (double) b->ts.sec + b->ts.frac / 4294967296.0);
-    for (i = 0; i < b->len; i++) {
-        lo_message_pp(b->msgs[i]);
-    }
-    printf("\n");
+    size_t len = 4;
+    int *state = calloc(len, sizeof(int));
+
+    state[0] = 1;
+    state = lo_bundle_pp_internal(b, 0, state, &len);
+    free (state);
 }
 
 /* vi:set ts=8 sts=4 sw=4: */

--- a/src/lo_types_internal.h
+++ b/src/lo_types_internal.h
@@ -82,6 +82,7 @@ typedef struct _lo_message {
     lo_arg **argv;
     /* timestamp from bundle (LO_TT_IMMEDIATE for unbundled messages) */
     lo_timetag ts;
+		size_t refcount;
 } *lo_message;
 
 typedef int (*lo_method_handler) (const char *path, const char *types,
@@ -156,13 +157,26 @@ typedef struct _lo_server_thread {
 typedef void *lo_server_thread;
 #endif
 
-typedef struct _lo_bundle {
+typedef struct _lo_bundle *lo_bundle;
+
+typedef struct _lo_element {
+	lo_element_type type;
+	union {
+		lo_bundle bundle;
+		struct {
+			lo_message msg;
+			const char *path;
+		} message;
+	} content;
+} lo_element;
+
+struct _lo_bundle {
     size_t size;
     size_t len;
     lo_timetag ts;
-    lo_message *msgs;
-    char **paths;
-} *lo_bundle;
+		lo_element *elmnts;
+		size_t refcount;
+};
 
 typedef struct _lo_strlist {
     char *str;

--- a/src/message.c
+++ b/src/message.c
@@ -81,6 +81,7 @@ lo_message lo_message_new()
     m->source = NULL;
     m->argv = NULL;
     m->ts = LO_TT_IMMEDIATE;
+    m->refcount = 0;
 
     return m;
 }

--- a/src/send.c
+++ b/src/send.c
@@ -585,8 +585,8 @@ int lo_send_bundle(lo_address a, lo_bundle b)
 
 int lo_send_bundle_from(lo_address a, lo_server from, lo_bundle b)
 {
-    const size_t data_len = lo_bundle_length(b);
-    char *data = lo_bundle_serialise(b, NULL, NULL);
+    size_t data_len;
+    char *data = lo_bundle_serialise(b, NULL, &data_len);
 
     // Send the bundle
     int ret = send_data(a, from, data, data_len);


### PR DESCRIPTION
I'd not only like to receive, but also create nested bundles with liblo, so this patch adds support for creating and sending nested bundles.

There's just one new function for the API: lo_bundle_add_bundle

This is a proposal for a simple initial patch which makes use of the existing infrastructure introducing the concept of bundle elements (which can be either a message or an other bundle).

However, by introducing nested bundles, we introduce all the problems of handling potential cyclic references in the bundle trees and the serialisation step will run havok (like a bundle in a bundle which has the parent bundle as an element).

That's something that's not yet cared for by this patch (because it's not a trivial problem) and would need some clever approach to the problem. Any ideas?
