### PR TITLE
Cloning of lo_message objects

### DIFF
--- a/lo/lo_lowlevel.h
+++ b/lo/lo_lowlevel.h
@@ -110,6 +110,11 @@ int lo_send_bundle_from(lo_address targ, lo_server serv, lo_bundle b);
 lo_message lo_message_new();
 
 /**
+ * \brief Create a new lo_message object by cloning an already existing one
+ */
+lo_message lo_message_clone(lo_message m);
+
+/**
  * \brief Free memory allocated by lo_message_new() and any subsequent
  * \ref lo_message_add_int32 lo_message_add*() calls.
  */

--- a/src/message.c
+++ b/src/message.c
@@ -85,6 +85,32 @@ lo_message lo_message_new()
     return m;
 }
 
+lo_message lo_message_clone(lo_message m)
+{
+    if (!m) {
+	return NULL;
+    }
+
+    lo_message c = malloc(sizeof(struct _lo_message));
+    if (!c) {
+	return NULL;
+    }
+
+    c->types = calloc(m->typesize, sizeof(char));
+    strcpy (c->types, m->types);
+    c->typelen = m->typelen;
+    c->typesize = m->typesize;
+    c->data = calloc(m->datasize, sizeof(uint8_t));
+    memcpy(c->data, m->data, m->datalen);
+    c->datalen = m->datalen;
+    c->datasize = m->datasize;
+    c->source = NULL;
+    c->argv = NULL;
+    c->ts = LO_TT_IMMEDIATE;
+    
+    return c;
+}
+
 void lo_message_free(lo_message m)
 {
     if (m) {


### PR DESCRIPTION
Sometimes its handy if you're able to clone a lo_message object, e.g. always then when you want to first aggregate received messages (e.g. from a bundle) and only later process them after you've already returned the method handler (as the message object is freed right after the method call by liblo).

The only way right now to clone a lo_message object is to first serialize it to a temporary buffer and then deserialize it again to a lo_message object which is utterly inefficient.

So here is a dedicated 'lo_message_clone' function which does it efficiently.
