### PR TITLE
UDP resolve enable in lo_server struct

### DIFF
--- a/lo/lo_lowlevel.h
+++ b/lo/lo_lowlevel.h
@@ -784,6 +784,21 @@ char *lo_server_get_url(lo_server s);
 int lo_server_enable_queue(lo_server s, int queue_enabled,
                            int dispatch_remaining);
 
+/**
+ * \brief Toggle UDP resolve upon reception.
+ * If resolve is enabled, the source socket address of each message received via UDP
+ * is translated individually to a location and service name which adds some
+ * computation time to dispatching. This source address of a message then can be
+ * accessed by lo_message_get_source(). If you don't care where your message come
+ * from, you can disable the resolution step but won't be able to access the source
+ * address by lo_message_get_source() anymore.
+ * \param s a liblo server
+ * \param resolve_enabled Zero to disable resolve, non-zero to enable.
+ * \return The previous state of resolve behaviour. Zero if resolve
+ *         was previously disabled, non-zero otherwiese.
+ */
+int lo_server_enable_udp_resolve(lo_server s, int udp_resolve_enabled);
+
 /** 
  * \brief Return true if there are scheduled events (eg. from bundles) 
  * waiting to be dispatched by the server

--- a/src/lo_types_internal.h
+++ b/src/lo_types_internal.h
@@ -119,6 +119,7 @@ typedef struct _lo_server {
     int protocol;
     void *queued;
     int queue_enabled;
+		int udp_resolve_enabled;
     struct sockaddr_storage addr;
     socklen_t addr_len;
     int sockets_len;

--- a/src/server.c
+++ b/src/server.c
@@ -282,6 +282,7 @@ lo_server lo_server_new_with_proto_internal(const char *group,
     s->path = NULL;
     s->queued = NULL;
     s->queue_enabled = 1;
+    s->udp_resolve_enabled = 1;
     s->sockets_len = 1;
     s->sockets_alloc = 2;
     s->sockets = calloc(2, sizeof(*(s->sockets)));
@@ -703,6 +704,14 @@ int lo_server_enable_queue(lo_server s, int queue_enabled,
 
     if (!queue_enabled && dispatch_remaining && s->queued)
         dispatch_queued(s, 1);
+
+    return prev;
+}
+
+int lo_server_enable_udp_resolve(lo_server s, int udp_resolve_enabled)
+{
+    int prev = s->udp_resolve_enabled;
+    s->udp_resolve_enabled = udp_resolve_enabled;
 
     return prev;
 }
@@ -1611,7 +1620,7 @@ static void dispatch_method(lo_server s, const char *path,
     const char *pptr;
 
     //inet_ntop(s->addr.ss_family, &s->addr.padding, hostname, sizeof(hostname));
-    if (s->protocol == LO_UDP && s->addr_len > 0) {
+    if ( (s->protocol == LO_UDP) && (s->udp_resolve_enabled) && (s->addr_len > 0) ) {
         err = getnameinfo((struct sockaddr *) &s->addr, s->addr_len,
                           hostname, sizeof(hostname), portname,
                           sizeof(portname),


### PR DESCRIPTION
While profiling my application (OSC via UDP), I've found that liblo spends a considerable amount (in my case its 1/3 of CPU time at least, and I'm doing a lot of computation) of time resolving the address of an incoming packet (getnameinfo in src/server.c).

Some users may just not care about where an UDP packet was coming from.
This patch introduces a switch that can turn this resolution step off for servers using UDP.
