### PR TITLE
New API to set a server's options, lo_server_set_flags

### DIFF
--- a/lo/lo_lowlevel.h
+++ b/lo/lo_lowlevel.h
@@ -645,6 +645,11 @@ lo_server lo_server_new_multicast_iface(const char *group, const char *port,
                                         lo_err_handler err_h);
 
 /**
+ * \brief Sets the server's options.
+ */
+void lo_server_set_flags(lo_server server, lo_server_flags flag);
+
+/**
  * \brief Free up memory used by the lo_server object
  */
 void lo_server_free(lo_server s);

--- a/lo/lo_osc_types.h
+++ b/lo/lo_osc_types.h
@@ -158,6 +158,13 @@ typedef enum {
     LO_NODELAY=0x02,  /*!< Set the TCP_NODELAY socket option. */
 } lo_proto_flags;
 
+/** \brief Bitflags for optional server features, set by
+ *         lo_server_set_flags(). */
+typedef enum {
+    LO_SERVER_NO_FLAG=0x00,              /*!< default value */
+    LO_SERVER_DISABLE_COERCION=0x01 /*!< default value */
+} lo_server_flags;
+
 /** @} */
 
 #endif

--- a/src/lo_types_internal.h
+++ b/src/lo_types_internal.h
@@ -123,6 +123,7 @@ typedef struct _lo_server {
     char *hostname;
     char *path;
     int protocol;
+    lo_server_flags flags;
     void *queued;
     int queue_enabled;
     struct sockaddr_storage addr;

--- a/src/server.c
+++ b/src/server.c
@@ -276,6 +276,7 @@ lo_server lo_server_new_with_proto_internal(const char *group,
     s->ai = NULL;
     s->hostname = NULL;
     s->protocol = proto;
+    s->flags = LO_SERVER_NO_FLAG;
     s->port = 0;
     s->path = NULL;
     s->queued = NULL;
@@ -617,6 +618,16 @@ int lo_server_join_multicast_group(lo_server s, const char *group,
     }
 
     return 0;
+}
+
+void lo_server_set_flags(lo_server s, lo_server_flags flags)
+{
+    s->flags = flags;
+}
+
+int lo_server_should_coerce_args(lo_server s)
+{
+    return (s->flags & LO_SERVER_DISABLE_COERCION) == 0;
 }
 
 void lo_server_free(lo_server s)
@@ -1643,7 +1654,7 @@ static void dispatch_method(lo_server s, const char *path,
                 ret = it->handler(pptr, types, msg->argv, argc, msg,
                                   it->user_data);
 
-            } else if (lo_can_coerce_spec(types, it->typespec)) {
+            } else if (lo_server_should_coerce_args(s) && lo_can_coerce_spec(types, it->typespec)) {
                 lo_arg **argv = NULL;
 
                 if (argc > 0) {


### PR DESCRIPTION
One bitfield is currently available `LO_SERVER_DISABLE_COERCION` when set, prevents the dispatch to coerce an input message's arguments.
