### PR TITLE
initialize lo_message refcount

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -115,6 +115,7 @@ lo_message lo_message_clone(lo_message m)
     c->source = NULL;
     c->argv = NULL;
     c->ts = LO_TT_IMMEDIATE;
+    c->refcount = 0;
     
     return c;
 }
@@ -877,6 +878,7 @@ lo_message lo_message_deserialise(void *data, size_t size, int *result)
     msg->source = NULL;
     msg->argv = NULL;
     msg->ts = LO_TT_IMMEDIATE;
+    msg->refcount = 0;
 
     // path
     len = lo_validate_string(data, remain);


### PR DESCRIPTION
This commit initializes the refcount property of an allocated lo_message in lo_message_clone() and lo_message_deserialize(). The refcount is used to evaluate a conditional in lo_message_free(), so valgrind was complaining...

Joe
