### PR TITLE
Only filter out -Werror, not -Werror=something

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -106,7 +106,7 @@ AC_ARG_ENABLE(threads,
   [want_threads=yes])
 
 # Filter out -Werror temporarily, otherwise library checks can fail
-CFLAGS_nowerror="`echo $CFLAGS | sed s/-Werror//`"
+CFLAGS_nowerror="`echo $CFLAGS | sed 's/-Werror\([^=]\|$\)//'`"
 if test "$CFLAGS" = "$CFLAGS_nowerror"; then
   CFLAGS_werror=
 else


### PR DESCRIPTION
Prevents build failures, because the CFLAGS would contain =something in the arguments
