### PR TITLE
Set HTML_TIMESTAMP from YES to NO to make build reproducible

### DIFF
--- a/doc/reference.doxygen.in
+++ b/doc/reference.doxygen.in
@@ -1110,7 +1110,7 @@ HTML_COLORSTYLE_GAMMA  = 80
 # The default value is: YES.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_TIMESTAMP         = YES
+HTML_TIMESTAMP         = NO
 
 # If the HTML_DYNAMIC_SECTIONS tag is set to YES then the generated HTML
 # documentation will contain sections that can be hidden and shown after the


### PR DESCRIPTION
Forwarded from [1].

The reproducible builds effort in Debian found out liblo is not reproducibly built because doxygen embeds a timestamp. Here reproducibly means rebuilding the package results in a bit-for-bit identical binary package.

I don't think the timestamps in the doxygen documentation add much value, so please consider applying. FWIW, doxygen upstream changed the default to NO.

[1] https://bugs.debian.org/789040