### PR TITLE
C++: create methods to retrieve path strings and type specifications of all added handlers.

### DIFF
--- a/examples/cpp_example.cpp
+++ b/examples/cpp_example.cpp
@@ -54,6 +54,12 @@ int main()
     st.start();
 
     /*
+     * Display the paths and type specifications of added methods
+     */
+    std::cout << "Added methods [path,types]:" << std::endl
+              << st.added_paths_str() << std::endl;
+
+    /*
      * Send some messages to the server we just created on localhost.
      */
     lo::Address a("localhost", "9000");

--- a/lo/lo_cpp.h
+++ b/lo/lo_cpp.h
@@ -481,6 +481,26 @@ namespace lo {
             lo_server_del_method(server, path, typespec);
         }
 
+        std::string added_paths_str( void ) const
+        {
+            std::ostringstream added_paths;
+            for(auto it = _handlers.begin(); it!=_handlers.end(); ++it )
+                added_paths << it->first << std::endl;
+
+            return added_paths.str();
+        }
+
+        std::list<std::pair<std::string,std::string>>
+                                added_paths_list( void ) const
+        {
+            std::list<std::pair<std::string,std::string>> added_paths;
+            for(auto it = _handlers.begin(); it!=_handlers.end(); ++it )
+                added_paths.push_back(std::pair<std::string,std::string>(
+                                    it->first.substr(0,it->first.find(',')),
+                                    it->first.substr(it->first.find(',')+1) ));
+            return added_paths;
+        }
+
         int dispatch_data(void *data, size_t size)
             { return lo_server_dispatch_data(server, data, size); }
 


### PR DESCRIPTION
Once many of methods are added to a server, I find it hard to recall the path and types of every one of them, and wanted a way to output them.

I created two methods:

    std::string added_paths_str( void ) const

which constructs a string of the .first members of every element in _handlers exactly as they are stored, separated by newlines.

    std::list<std::pair<std::string,std::string>>
                                  added_paths_list( void ) const
which returns a pair containing the path string as .first and the type specifications as .second.

I believe these methods could additionally be useful in discovery of options, communicating valid paths to a controller program for example.