### PR TITLE
Fixes for mingw64/mingw32

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -188,6 +188,7 @@ AC_CHECK_HEADERS([netdb.h netinet/in.h stdlib.h string.h sys/socket.h unistd.h])
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
 AC_TYPE_SIZE_T
+AC_TYPE_UINTPTR_T
 
 # Check for features
 AC_CHECK_FUNC([select], [AC_DEFINE(HAVE_SELECT, [1], [Define to 1 if select() is available.])], [

--- a/configure.ac
+++ b/configure.ac
@@ -191,6 +191,7 @@ AC_TYPE_SIZE_T
 AC_TYPE_UINTPTR_T
 
 # Check for features
+AC_CHECK_FUNC([inet_pton], [AC_DEFINE(HAVE_INET_PTON, [1], [Define to 1 if inet_pton() is available.])])
 AC_CHECK_FUNC([select], [AC_DEFINE(HAVE_SELECT, [1], [Define to 1 if select() is available.])], [
      AC_MSG_CHECKING([for select in ws2_32])
      extralibs="-lws2_32 -liphlpapi"
@@ -202,7 +203,6 @@ AC_CHECK_FUNC([select], [AC_DEFINE(HAVE_SELECT, [1], [Define to 1 if select() is
                  is_windows=yes],[AC_MSG_RESULT(no)])
 ])
 AC_CHECK_FUNC([poll], [AC_DEFINE(HAVE_POLL, [1], [Define to 1 if poll() is available.])])
-AC_CHECK_FUNC([inet_pton], [AC_DEFINE(HAVE_INET_PTON, [1], [Define to 1 if inet_pton() is available.])])
 
 AM_CONDITIONAL(WINDOWS, test x$is_windows = xyes)
 AM_CONDITIONAL(WINDOWS_DLL, test x$is_windows = xyes && test x$enable_shared = xyes)

--- a/src/message.c
+++ b/src/message.c
@@ -116,7 +116,7 @@ lo_message lo_message_clone(lo_message m)
     c->argv = NULL;
     c->ts = LO_TT_IMMEDIATE;
     c->refcount = 0;
-    
+
     return c;
 }
 
@@ -260,8 +260,8 @@ int lo_message_add_varargs_internal(lo_message msg, const char *types,
     }
 #ifndef USE_ANSI_C
     void *i = va_arg(ap, void *);
-    if (((unsigned long)i & 0xFFFFFFFFUL)
-	!= ((unsigned long)LO_MARKER_A & 0xFFFFFFFFUL))
+    if (((uintptr_t)i & 0xFFFFFFFFUL)
+	!= ((uintptr_t)LO_MARKER_A & 0xFFFFFFFFUL))
     {
         ret = -2;               // bad format/args
         fprintf(stderr,
@@ -272,8 +272,8 @@ int lo_message_add_varargs_internal(lo_message msg, const char *types,
         return ret;
     }
     i = va_arg(ap, void *);
-    if (((unsigned long)i & 0xFFFFFFFFUL)
-	!= ((unsigned long)LO_MARKER_B & 0xFFFFFFFFUL))
+    if (((uintptr_t)i & 0xFFFFFFFFUL)
+	!= ((uintptr_t)LO_MARKER_B & 0xFFFFFFFFUL))
     {
         ret = -2;               // bad format/args
         fprintf(stderr,

--- a/src/message.c
+++ b/src/message.c
@@ -1010,7 +1010,7 @@ void lo_arg_pp(lo_type type, void *data)
 void lo_arg_pp_internal(lo_type type, void *data, int bigendian)
 {
     lo_pcast32 val32;
-    lo_pcast64 val64;
+    lo_pcast64 val64 = {0};
     lo_timetag valtt = { 0, 1 };
     int size;
     int i;

--- a/src/tools/oscsend.c
+++ b/src/tools/oscsend.c
@@ -91,6 +91,7 @@ lo_message create_message(char **argv)
     }
 
     argi = 1;
+    arg = NULL;
     for (i = 0; i < values; i++) {
 		switch(types[i]) {
 		case LO_INT32:


### PR DESCRIPTION
This fixes building and testing liblo with mingw64 and mingw32.
