### PR TITLE
Fix to allow building from CMake with MSVC

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -52,10 +52,6 @@ set(LIBRARY_HEADERS
 set(OSCDUMP_SOURCES ../src/tools/oscdump.c)
 set(OSCSEND_SOURCES ../src/tools/oscsend.c)
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-    list(APPEND LIBRARY_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/src/liblo.def)
-endif()
-
 check_symbol_exists(poll poll.h HAVE_POLL)
 check_symbol_exists(select sys/select.h HAVE_SELECT)
 check_symbol_exists(getifaddrs sys/types.h ifaddrs.h HAVE_GETIFADDRS)
@@ -82,8 +78,8 @@ if(THREADING)
     check_include_files(pthread.h HAVE_LIBPTHREAD)
 
     include(FindThreads)
-    set(CMAKE_THREAD_PREFER_PTHREAD ON)
-    find_package(Threads)
+    set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+    find_package(Threads REQUIRED)
 
     target_link_libraries(${LIBRARY_SHARED} Threads::Threads)
 
@@ -97,7 +93,9 @@ endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     target_link_libraries(${LIBRARY_SHARED} "user32" "wsock32" "ws2_32" "iphlpapi")
-    target_link_libraries(${LIBRARY_SHARED} "pthreadVC2")
+    if(THREADING)
+        target_link_libraries(${LIBRARY_SHARED} "pthreadVC2")
+    endif()
 
     set_target_properties(${LIBRARY_SHARED} PROPERTIES
         COMPILE_DEFINITIONS "-DLIBLO_DLL")

--- a/cmake/config-msvc.h.in
+++ b/cmake/config-msvc.h.in
@@ -8,7 +8,7 @@
 #define ENABLE_NETWORK_TESTS 1
 
 /* Define this to enable threads. */
-#cmakedefine01 ENABLE_THREADS
+#cmakedefine ENABLE_THREADS
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
 /* #undef HAVE_DLFCN_H */


### PR DESCRIPTION
This fixes two issues: One with the non-threading build, the pthread library was still being included and failing because of that.

Secondly, the .def file was being add to the msvc projects causing it to fail for every type of build.