### PR TITLE
Removal of pthreads from MSVC build and use of native threads instead

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -75,17 +75,19 @@ add_executable(${OSCSEND} ${OSCSEND_SOURCES})
 
 if(THREADING)
     set(ENABLE_THREADS 1)
-    check_include_files(pthread.h HAVE_LIBPTHREAD)
+    
+    if(NOT MSVC)
+        check_include_files(pthread.h HAVE_LIBPTHREAD)
+        set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+    endif()
 
     include(FindThreads)
-    set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
     find_package(Threads REQUIRED)
 
     target_link_libraries(${LIBRARY_SHARED} Threads::Threads)
 
     set(THREADS_INCLUDE
       "#include \"lo/lo_serverthread.h\"")
-
 else()
     set(THREADS_INCLUDE
       "/* lo/lo_serverthread.h unavailable (THREADING=OFF) */")
@@ -93,7 +95,7 @@ endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     target_link_libraries(${LIBRARY_SHARED} "user32" "wsock32" "ws2_32" "iphlpapi")
-    if(THREADING)
+    if(THREADING AND NOT MSVC)
         target_link_libraries(${LIBRARY_SHARED} "pthreadVC2")
     endif()
 

--- a/src/lo_types_internal.h
+++ b/src/lo_types_internal.h
@@ -44,7 +44,10 @@ typedef __int32 int32_t;
 #endif
 
 #ifdef ENABLE_THREADS
-#include <pthread.h>
+// MSVC won't have this
+# ifdef HAVE_PTHREADS_H
+#  include <pthread.h>
+# endif
 #endif
 
 #include "lo/lo_osc_types.h"
@@ -190,7 +193,11 @@ typedef void (*lo_server_thread_cleanup_callback)(struct _lo_server_thread *s,
                                                   void *user_data);
 typedef struct _lo_server_thread {
     lo_server s;
+#ifdef _MSC_VER
+    HANDLE thread;
+#else 
     pthread_t thread;
+#endif
     volatile int active;
     volatile int done;
     lo_server_thread_init_callback cb_init;


### PR DESCRIPTION
Hi again!

Decided that including pthreads on Windows is a pain so why not remove it altogether. There isn't really that much code to change anyways.

This is a preliminary review I guess. I need to test it a bit more but I think it looks fairly resonable.
Let me know what you think!