### PR TITLE
server: use correct poll.h header

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -51,7 +51,7 @@
 #include <netdb.h>
 #include <sys/socket.h>
 #ifdef HAVE_POLL
-#include <sys/poll.h>
+#include <poll.h>
 #endif
 #include <sys/un.h>
 #include <arpa/inet.h>


### PR DESCRIPTION
Fixes build with the musl C library:
    http://autobuild.buildroot.net/results/000a46954d0c6d3dbc4b4634a0d3a3c955fac679

This has also been verified to still build on glibc and uclibc.