### PR TITLE
src/server.c: fix stringop-truncation error

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -377,7 +377,7 @@ void lo_server_resolve_hostname(lo_server s)
         gethostname(hostname, sizeof(hostname));
         he = gethostbyname(hostname);
         if (he) {
-            strncpy(hostname, he->h_name, sizeof(hostname));
+            strncpy(hostname, he->h_name, sizeof(hostname) - 1);
         }
     }
 


### PR DESCRIPTION
Fixes:
 - http://autobuild.buildroot.org/results/62896bd6a1a30facaffd07a7a763831996dc8ea0

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>