### PR TITLE
adding get_port() member to ServerThread class

### DIFF
--- a/lo/lo_cpp.h
+++ b/lo/lo_cpp.h
@@ -774,6 +774,7 @@ namespace lo {
 
         void start() { lo_server_thread_start(server_thread); }
         void stop() { lo_server_thread_stop(server_thread); }
+        int get_port() { return lo_server_thread_get_port(server_thread); }
 
         operator lo_server_thread() const
             { return server_thread; }


### PR DESCRIPTION
This way the server can be created in C++ code more easily without an explicit port and the one chosen by the library can be obtained later on.