### PR TITLE
Support receiving double-ENDed SLIP packets

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1180,14 +1180,18 @@ int lo_server_recv_raw_stream_socket(lo_server s, int isock,
 
             msg_len = sc->buffer_read_offset - sc->buffer_msg_offset - sizeof(uint32_t);
 
-            // Store message length header
-            *(uint32_t*)(sc->buffer + sc->buffer_msg_offset) = htonl(msg_len);
+            // Skip empty messages, for instance for when sender is double-ENDing SLIP
+            if (msg_len)
+            {
+                // Store message length header
+                *(uint32_t*)(sc->buffer + sc->buffer_msg_offset) = htonl(msg_len);
 
-            // Advance to next message and zero the message length header
-            sc->buffer_msg_offset += msg_len + sizeof(uint32_t);
-            sc->buffer_read_offset += sizeof(uint32_t);
-            buffer_after += sizeof(uint32_t);
-            *(uint32_t*)(sc->buffer + sc->buffer_msg_offset) = 0;
+                // Advance to next message and zero the message length header
+                sc->buffer_msg_offset += msg_len + sizeof(uint32_t);
+                sc->buffer_read_offset += sizeof(uint32_t);
+                buffer_after += sizeof(uint32_t);
+                *(uint32_t*)(sc->buffer + sc->buffer_msg_offset) = 0;
+            }
 
             // Update how much memory still needs decoding.
             bytes_recv -= bytes_read;


### PR DESCRIPTION
(An explanation is given in the commit message of the commit. Forgive me for not duplicating it here.)

I don't know how widespread double-ENDing SLIP packets is, but I have come across one situation where it happens: Figure53's OSC implementation in their QLab software, as described [here](http://figure53.com/docs/qlab/v4/scripting/osc-dictionary-v4/).

I don't know how likely it is you have access to an iOS device to test, but this can be tested by attempting to read the OSC messages from the official iOS app for remote-controlling the aforementioned program, or by using the appropriate section of the third-party "Audio Toolbox" iOS app.

Admittedly I haven't tried sending messages, so that might be a future PR for you.