### PR TITLE
ESP32 compatibility

### DIFF
--- a/src/address.c
+++ b/src/address.c
@@ -174,7 +174,7 @@ static void lo_address_resolve_source(lo_address a)
             case EAI_NONAME:
                 lo_throw(s, err, "Cannot resolve", a->source_path);
                 break;
-#if !defined(WIN32) && !defined(_MSC_VER)
+#if !defined(WIN32) && !defined(_MSC_VER) && !defined(ESP_PLATFORM)
             case EAI_SYSTEM:
                 lo_throw(s, err, strerror(err), a->source_path);
                 break;

--- a/src/address.c
+++ b/src/address.c
@@ -174,7 +174,7 @@ static void lo_address_resolve_source(lo_address a)
             case EAI_NONAME:
                 lo_throw(s, err, "Cannot resolve", a->source_path);
                 break;
-#if !defined(WIN32) && !defined(_MSC_VER) && !defined(ESP_PLATFORM)
+#if !defined(WIN32) && !defined(_MSC_VER)
             case EAI_SYSTEM:
                 lo_throw(s, err, strerror(err), a->source_path);
                 break;

--- a/src/lo_types_internal.h
+++ b/src/lo_types_internal.h
@@ -18,7 +18,9 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #else
+#ifndef ESP_PLATFORM
 #define closesocket close
+#endif
 #include <netdb.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>

--- a/src/message.c
+++ b/src/message.c
@@ -934,7 +934,8 @@ lo_message lo_message_deserialise(void *data, size_t size, int *result)
 
     // args
     msg->data = malloc(remain);
-    if (NULL == msg->data) {
+    // ESP32 returns NULL for malloc(0)
+    if (NULL == msg->data && remain > 0) {
         res = LO_EALLOC;
         goto fail;
     }

--- a/src/server.c
+++ b/src/server.c
@@ -594,6 +594,8 @@ lo_server lo_server_new_with_proto_internal(const char *group,
                 int opt = 1;
                 setsockopt(s->sockets[0].fd, SOL_SOCKET, SO_BROADCAST,
 						   (char*)&opt, sizeof(int));
+                setsockopt(s->sockets[0].fd, IPPROTO_IP, IP_MULTICAST_LOOP,
+                           (char*)&opt, sizeof(int));
             }
         }
         if (s->sockets[0].fd == -1) {


### PR DESCRIPTION
I'm submitting this pull request to make liblo compatible with the libmapper Arduino library I'm working on. The port allows the usage of both liblo and libmapper on the Arduino ESP32 platform. 

malloc(0) returns either a null pointer or a unique pointer according to the standard
https://pubs.opengroup.org/onlinepubs/009695399/functions/malloc.html
Therefore I think it makes sense to check whether remain > 0

The IP_MULTICAST_LOOP socket option is necessary for libmapper and it defaults to 1 on Linux/macOS. On the ESP32 it defaults to 0. Therefore setting it to 1 should not break any current applications.

The closesocket thing is because the TCP/IP library LWIP defines closesocket as an inline function and therefore it can't be redefined.