### PR TITLE
Update pointer `buffer_after` after realloc of `sc->buffer`

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1203,6 +1203,7 @@ int lo_server_recv_raw_stream_socket(lo_server s, int isock,
             {
                 sc->buffer_size *= 2;
                 sc->buffer = (char*)  realloc(sc->buffer, sc->buffer_size);
+                buffer_after = sc->buffer + sc->buffer_read_offset;
             }
         }
 


### PR DESCRIPTION
When created, `buffer_after` is a pointer to the same `char`-array as the one that `sc->buffer` points to, albeit to a different point within it.

If the length of the `char`-array is deemed too small, it is increased via a `realloc()`, which typically relocates the array elsewhere (usually later) within memory.
    
Unfortunately, prior to this pull request, `buffer_after` was not updated to take into account this move.
    
As a result, on the next iteration of the encapsulating `while` loop, when the pointer arithmetic `buffer_after - sc->buffer` takes place the result is either: (a) a number that exceeds the length of the array, or (b) negative.

As the outcome of this is used to determine the position at which to start writing the next incoming message into the `char`-array, either answer causes a segfault.

----
(The above is the same as the text of the commit message.)

I'll admit that `C` is not a language I'm particularly familiar with, so although I *think* my explanation is correct, forgive me if I'm not using the correct terminology. Or just plain incorrect.