### PR TITLE
Fix `make check` with newer versions of clang.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,10 @@ matrix:
     osx_image: xcode10
     env: HOST="" MATRIX_EVAL="brew install autoconf-archive"
     compiler: clang
+  - os: osx
+    osx_image: xcode11.3
+    env: HOST="" MATRIX_EVAL="brew install autoconf-archive"
+    compiler: clang
 before_install:
   - eval "${MATRIX_EVAL}"
 script:  pwd && echo MINGW_ON_LINUX=$MINGW_ON_LINUX && mkdir $PWD/inst && (./autogen.sh --host=$HOST --disable-debug --prefix=$PWD/inst || (cat config.log; false)) && make && ([ x = x$MINGW_ON_LINUX ] && (make check || (for i in src/*.log; do echo === $i ===; cat $i; done; false)) || true) && make install && find inst

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,21 @@ AC_COMPILE_IFELSE(
   [AC_MSG_RESULT([no])
    CFLAGS="$_CFLAGS"])
 
+# If we can add -Wunused-lambda-capture.
+# This is needed for cpp_test.cpp to compile with clang >= 11
+AC_MSG_CHECKING([whether can add -Wunused-lambda-capture (C++)])
+_CFLAGS="$CFLAGS"
+CFLAGS="$_CFLAGS -Qunused-arguments"
+AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM([],[])],
+  [AC_MSG_RESULT([yes])
+   CFLAGS="$_CFLAGS"
+   have_unused_lambda_capture=yes],
+  [AC_MSG_RESULT([no])
+   CFLAGS="$_CFLAGS"
+   have_unused_lambda_capture=no])
+AM_CONDITIONAL([HAVE_UNUSED_LAMBDA_CAPTURE],[test x$have_unused_lambda_capture = xyes])
+
 # Since we don't require C99, format code for long long int can vary
 # in some compilers.  (In particular, MingW seems to require "I64"
 # instead of "ll")

--- a/configure.ac
+++ b/configure.ac
@@ -67,21 +67,6 @@ AC_COMPILE_IFELSE(
   [AC_MSG_RESULT([no])
    CFLAGS="$_CFLAGS"])
 
-# If we can add -Wunused-lambda-capture.
-# This is needed for cpp_test.cpp to compile with clang >= 11
-AC_MSG_CHECKING([whether can add -Wunused-lambda-capture (C++)])
-_CFLAGS="$CFLAGS"
-CFLAGS="$_CFLAGS -Qunused-arguments"
-AC_COMPILE_IFELSE(
-  [AC_LANG_PROGRAM([],[])],
-  [AC_MSG_RESULT([yes])
-   CFLAGS="$_CFLAGS"
-   have_unused_lambda_capture=yes],
-  [AC_MSG_RESULT([no])
-   CFLAGS="$_CFLAGS"
-   have_unused_lambda_capture=no])
-AM_CONDITIONAL([HAVE_UNUSED_LAMBDA_CAPTURE],[test x$have_unused_lambda_capture = xyes])
-
 # Since we don't require C99, format code for long long int can vary
 # in some compilers.  (In particular, MingW seems to require "I64"
 # instead of "ll")

--- a/src/cpp_test.cpp
+++ b/src/cpp_test.cpp
@@ -122,14 +122,9 @@ void init(lo::Server &s)
     s.add_method("test11", "is", [j](const char *types, lo_arg **argv, int argc, lo_message msg)
                  {printf("test11.2: %d, %s, %d, %s -- ", j, types, argv[0]->i, &argv[1]->s); lo_message_pp(msg);});
 
-#ifdef HAVE_UNUSED_LAMBDA_CAPTURE
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-lambda-capture."
     j*=2;
     s.add_method("test12", "i", [j](const lo::Message m)
-                 {printf("test12 source: %s\n", m.source().url().c_str());});
-#pragma clang diagnostic pop
-#endif
+                 {printf("test12: %d, source: %s\n", j, m.source().url().c_str());});
 
     s.add_method(0, 0, [](const char *path, lo_message m){printf("generic: %s ", path); lo_message_pp(m);});
 

--- a/src/cpp_test.cpp
+++ b/src/cpp_test.cpp
@@ -122,9 +122,12 @@ void init(lo::Server &s)
     s.add_method("test11", "is", [j](const char *types, lo_arg **argv, int argc, lo_message msg)
                  {printf("test11.2: %d, %s, %d, %s -- ", j, types, argv[0]->i, &argv[1]->s); lo_message_pp(msg);});
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-lambda-capture"
     j*=2;
     s.add_method("test12", "i", [j](const lo::Message m)
                  {printf("test12 source: %s\n", m.source().url().c_str());});
+#pragma clang diagnostic pop
 
     s.add_method(0, 0, [](const char *path, lo_message m){printf("generic: %s ", path); lo_message_pp(m);});
 

--- a/src/cpp_test.cpp
+++ b/src/cpp_test.cpp
@@ -122,12 +122,14 @@ void init(lo::Server &s)
     s.add_method("test11", "is", [j](const char *types, lo_arg **argv, int argc, lo_message msg)
                  {printf("test11.2: %d, %s, %d, %s -- ", j, types, argv[0]->i, &argv[1]->s); lo_message_pp(msg);});
 
+#ifdef HAVE_UNUSED_LAMBDA_CAPTURE
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
+#pragma clang diagnostic ignored "-Wunused-lambda-capture."
     j*=2;
     s.add_method("test12", "i", [j](const lo::Message m)
                  {printf("test12 source: %s\n", m.source().url().c_str());});
 #pragma clang diagnostic pop
+#endif
 
     s.add_method(0, 0, [](const char *path, lo_message m){printf("generic: %s ", path); lo_message_pp(m);});
 


### PR DESCRIPTION
`make check` with Apple clang version 11.0.0 (clang-1100.0.33.16) fails with the following:

```
$ make check
Making check in src
Making check in .
g++ -DHAVE_CONFIG_H -I. -I..   -g -O0 -I.. -std=c++11 -Qunused-arguments -O0 -g -Wall -Werror -DDEBUG -MT cpp_test-cpp_test.o -MD -MP -MF .deps/cpp_test-cpp_test.Tpo -c -o cpp_test-cpp_test.o `test -f 'cpp_test.cpp' || echo './'`cpp_test.cpp
cpp_test.cpp:126:34: error: lambda capture 'j' is not used [-Werror,-Wunused-lambda-capture]
    s.add_method("test12", "i", [j](const lo::Message m)
                                 ^
1 error generated.
make[2]: *** [cpp_test-cpp_test.o] Error 1
make[1]: *** [check-recursive] Error 1
make: *** [check-recursive] Error 1
```

I tried changing this in `src/Makefile.am`:

```
cpp_test_CXXFLAGS = -I$(top_srcdir)
```

to

```
cpp_test_CXXFLAGS = -I$(top_srcdir) -Wunused-lambda-capture
```

But `-Werror` from `CXXFLAGS` overrides `cpp_test_CXXFLAGS` in the generated Makefile because of the order of arguments:

```
cpp_test-cpp_test.o: cpp_test.cpp
	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(cpp_test_CXXFLAGS) $(CXXFLAGS) -MT cpp_test-cpp_test.o -MD -MP -MF $(DEPDIR)/cpp_test-cpp_test.Tpo -c -o cpp_test-cpp_test.o `test -f 'cpp_test.cpp' || echo '$(srcdir)/'`cpp_test.cpp
	$(AM_V_at)$(am__mv) $(DEPDIR)/cpp_test-cpp_test.Tpo $(DEPDIR)/cpp_test-cpp_test.Po
```

~~So, I think implementing this as a clang-specific pragma makes sense. If there is a way to do this in Makefile.am rather than in the source file I would love to know how.~~ This ended up being a much simpler fix than I initially thought.

I've also updated the travis config to run tests with this version of clang on OSX.

Build: https://travis-ci.org/elijahr/liblo/builds/642682851