### PR TITLE
Treat any IP address that ends with 255 as broadcast address

### DIFF
--- a/src/send.c
+++ b/src/send.c
@@ -333,8 +333,8 @@ static int create_socket(lo_address a)
             struct sockaddr_in *si = (struct sockaddr_in *) a->ai->ai_addr;
             unsigned char *ip = (unsigned char *) &(si->sin_addr);
 
-            if (ip[0] == 255 && ip[1] == 255 && ip[2] == 255
-                && ip[3] == 255) {
+            if (/*ip[0] == 255 && ip[1] == 255 && ip[2] == 255
+                &&*/ ip[3] == 255) {
                 int opt = 1;
                 setsockopt(a->socket, SOL_SOCKET, SO_BROADCAST,
 						   (const char*)&opt, sizeof(int));


### PR DESCRIPTION
This will allow you to also broadcast within a specific subnet, like 192.168.2.255 (received by anyone on the 192.168.2.* subnet)