### PR TITLE
Avoid #includ'ing cassert into lo namespace

### DIFF
--- a/lo/lo_cpp.h
+++ b/lo/lo_cpp.h
@@ -13,6 +13,9 @@
 #include <string>
 #include <sstream>
 #include <initializer_list>
+#ifndef LO_USE_EXCEPTIONS
+#include <cassert>
+#endif
 
 /**
  * \file lo_cpp.h The liblo C++ wrapper
@@ -125,7 +128,6 @@ namespace lo {
 #define LO_CHECK_BEFORE if (!is_valid()) throw Invalid();
 #define LO_CHECK_AFTER if (!is_valid()) throw Error();
 #else
-#include <cassert>
 #define LO_CHECK_BEFORE assert(is_valid());
 #define LO_CHECK_AFTER
 #endif


### PR DESCRIPTION
The placement of #include <cassert> in the middle of the header
places any symbols declared into that namespace. This will break
anything which includes lo_cpp.h before including (possibly via
other headers) <cassert>, as the header guards against re-inclusion,
so anything expecting to find eg. __assert_fail in the global
namespace won't find it.