### PR TITLE
Discard corrupted messages when receiving

### DIFF
--- a/lo/lo_serverthread.h
+++ b/lo/lo_serverthread.h
@@ -156,7 +156,7 @@ void lo_server_thread_del_method(lo_server_thread st, const char *path,
 /**
  * \brief Delete an OSC method from the specified server thread.
  *
- * \param s The server thread the method is to be removed from.
+ * \param st The server thread the method is to be removed from.
  * \param m The lo_method identifier returned from lo_server_add_method for
  *          the method to delete from the server.
  * \return Non-zero if it was not found in the list of methods for the server.

--- a/src/message.c
+++ b/src/message.c
@@ -904,6 +904,11 @@ lo_message lo_message_deserialise(void *data, size_t size, int *result)
         res = LO_EINVALIDPATH;  // invalid path string
         goto fail;
     }
+    char *path = (char*)data;
+    if (path[0] != '/' && path[0] != '#') {
+        res = LO_EINVALIDPATH;  // invalid path string
+        goto fail;
+    }
     remain -= len;
 
     // types

--- a/src/send.c
+++ b/src/send.c
@@ -229,7 +229,7 @@ int lo_send_from(lo_address to, lo_server from, lo_timetag ts,
 }
 #endif
 
-/* Don't call lo_send_from_internal directly, use macros wrapping this 
+/* Don't call lo_send_from_internal directly, use macros wrapping this
  * function with appropriate values for file and line */
 
 int lo_send_from_internal(lo_address to, lo_server from, const char *file,
@@ -409,7 +409,7 @@ static int create_socket(lo_address a)
 				   (const char*)&option, sizeof(option));
     }
 #endif
-    
+
     return 0;
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -1063,15 +1063,16 @@ int lo_server_recv_raw_stream_socket(lo_server s, int isock,
     char *stack_buffer = 0, *read_into;
     uint32_t msg_len;
 	int buffer_bytes_left, bytes_recv;
-	ssize_t bytes_wrote, size;
+	ssize_t bytes_written, size;
     *pdata = 0;
 
   again:
 
     // Check if there is already a message waiting in the buffer.
-    if ((*pdata = lo_server_buffer_copy_for_dispatch(s, isock, psize)))
+    if ((*pdata = lo_server_buffer_copy_for_dispatch(s, isock, psize))) {
         // There could be more data, so return true.
         return 1;
+    }
 
     buffer_bytes_left = sc->buffer_size - sc->buffer_read_offset;
 
@@ -1100,9 +1101,10 @@ int lo_server_recv_raw_stream_socket(lo_server s, int isock,
     {
         sc->buffer_size = size;
         sc->buffer = (char*) realloc(sc->buffer, sc->buffer_size);
-        if (!sc->buffer)
+        if (!sc->buffer) {
             // Out of memory
             return 0;
+        }
     }
 
     // Read as much as we can into the remaining buffer memory.
@@ -1176,9 +1178,9 @@ int lo_server_recv_raw_stream_socket(lo_server s, int isock,
                            &sc->slip_state, &bytes_read) == 0)
         {
             // We have a whole message in the buffer.
-            size_t bytes_wrote = buffer_after - sc->buffer - sc->buffer_read_offset;
+            size_t bytes_written = buffer_after - sc->buffer - sc->buffer_read_offset;
 
-            sc->buffer_read_offset += bytes_wrote;
+            sc->buffer_read_offset += bytes_written;
 
             msg_len = sc->buffer_read_offset - sc->buffer_msg_offset - sizeof(uint32_t);
 
@@ -1211,8 +1213,8 @@ int lo_server_recv_raw_stream_socket(lo_server s, int isock,
 
         // Any data left over is left in the buffer, so update the
         // read offset to indicate the end of it.
-        bytes_wrote = buffer_after - sc->buffer - sc->buffer_read_offset;
-        sc->buffer_read_offset += bytes_wrote;
+        bytes_written = buffer_after - sc->buffer - sc->buffer_read_offset;
+        sc->buffer_read_offset += bytes_written;
     }
     else
     {


### PR DESCRIPTION
When playing with multithreaded senders I realized that corrupted messages are not released from the receive buffer leading to unnecessary increases to the buffer size. This change copies and returns valid messages from the buffer as before, but decrements the buffer read offset regardless, effectively removing corrupted data from the buffer.