### PR TITLE
Fix 2 "maybe uninitialized" compiler warnings

### DIFF
--- a/src/tools/oscsend.c
+++ b/src/tools/oscsend.c
@@ -255,7 +255,7 @@ lo_message create_message(char **argv)
 
 int main(int argc, char **argv)
 {
-    lo_address target;
+    lo_address target = NULL;
     lo_message message;
     int ret, i=1, dump_to_file=0, dump_to_stdout=0;
     char file_uri[256];

--- a/src/tools/oscsendfile.c
+++ b/src/tools/oscsendfile.c
@@ -277,7 +277,7 @@ int send_file(lo_address target, double speed) {
     const char *delim = " \r\n";
     char *args[64];
     char str[1024], *p, *s, *path;
-    lo_timetag tt_start = {0, 0}, tt_start_file, tt_now;
+    lo_timetag tt_start = {0, 0}, tt_start_file = {0, 0}, tt_now;
     lo_timetag tt1 = {0, 0}, tt2 = {0, 0}, *tt_last = &tt1, *tt_this = &tt2;
     int tt_init = 0, ret;
     lo_message m;


### PR DESCRIPTION
gcc 10.2 reported these 2 warnings using -Wmaybe-uninitialized