### PR TITLE
Fix compilation warning when compiling with 32 bit MinGW

### DIFF
--- a/src/test_bidirectional_tcp.c
+++ b/src/test_bidirectional_tcp.c
@@ -1,3 +1,6 @@
+#ifdef WIN32
+#include <process.h>
+#endif
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -34,7 +37,7 @@ int generic_handler(const char *path, const char *types, lo_arg ** argv,
 }
 
 #ifdef HAVE_WIN32_THREADS
-unsigned sendthread(void *arg)
+unsigned __attribute__((stdcall)) sendthread(void *arg)
 #else
 void *sendthread(void *arg)
 #endif


### PR DESCRIPTION
Compilation with 64 bit MinGW still works after this change.

Without this change, and with -Werror, MinGW32 had complained:
```
gcc -DHAVE_CONFIG_H -I. -I..    -Wall -I.. -DWIN32 -D_WIN32_WINNT=0x501 -O0 -g -Wall -Werror -DDEBUG -MT test_bidirectional_tcp-test_bidirectional_tcp.o -MD -MP -MF .deps/test_bidirectional_tcp-test_bidirectional_tcp.Tpo -c -o test_bidirectional_tcp-test_bidirectional_tcp.o `test -f 'test_bidirectional_tcp.c' || echo './'`test_bidirectional_tcp.c
test_bidirectional_tcp.c: In function 'main':
test_bidirectional_tcp.c:79:26: error: implicit declaration of function '_beginthreadex' [-Werror=implicit-function-declaration]
   79 |     HANDLE thr = (HANDLE)_beginthreadex(NULL, 0, &sendthread, s, 0, NULL);
      |                          ^~~~~~~~~~~~~~
cc1.exe: all warnings being treated as errors
make[3]: *** [Makefile:930: test_bidirectional_tcp-test_bidirectional_tcp.o] Error 1
```