### PR TITLE
VS2017 compiliation issues with empty struct definitions and <BaseTsd.h>

### DIFF
--- a/lo/lo_lowlevel.h
+++ b/lo/lo_lowlevel.h
@@ -31,6 +31,7 @@ extern "C" {
 #include <stdarg.h>
 #include <sys/types.h>
 #ifdef _MSC_VER
+#include <BaseTsd.h>
 typedef SSIZE_T ssize_t;
 #endif
 #include <stdint.h>

--- a/lo/lo_types.h
+++ b/lo/lo_types.h
@@ -42,14 +42,14 @@ extern "C" {
  *
  * Created by calls to lo_address_new() or lo_address_new_from_url().
  */
-typedef struct lo_address_ {} *lo_address;
+typedef struct lo_address_  *lo_address;
 
 /**
  * \brief A object to store an opaque binary data object.
  *
  * Can be passed over OSC using the 'b' type. Created by calls to lo_blob_new().
  */
-typedef struct lo_blob_ {} *lo_blob;
+typedef struct lo_blob_ *lo_blob;
 
 /**
  * \brief A low-level object used to represent messages passed over OSC.
@@ -57,7 +57,7 @@ typedef struct lo_blob_ {} *lo_blob;
  * Created by calls to lo_message_new(), arguments can be added with calls to
  * lo_message_add_*().
  */
-typedef struct lo_message_ {} *lo_message;
+typedef struct lo_message_ *lo_message;
 
 /**
  * \brief A low-level object used to represent bundles of messages passed over
@@ -66,7 +66,7 @@ typedef struct lo_message_ {} *lo_message;
  * Created by calls to lo_bundle_new(), messages can be added with calls to
  * lo_bundle_add_message().
  */
-typedef struct lo_bundle_ {} *lo_bundle;
+typedef struct lo_bundle_ *lo_bundle;
 
 /**
  * \brief An object representing an method on a server.
@@ -74,7 +74,7 @@ typedef struct lo_bundle_ {} *lo_bundle;
  * Returned by calls to lo_server_thread_add_method() and
  * lo_server_add_method().
  */
-typedef struct lo_method_ {} *lo_method;
+typedef struct lo_method_ *lo_method;
 
 /**
  * \brief An object representing an instance of an OSC server.
@@ -82,14 +82,14 @@ typedef struct lo_method_ {} *lo_method;
  * Created by calls to lo_server_new(). If you wish to have the server
  * operate in a background thread, use lo_server_thread instead.
  */
-typedef struct lo_server_ {} *lo_server;
+typedef struct lo_server_ *lo_server;
 
 /**
  * \brief An object representing a thread containing an OSC server.
  *
  * Created by calls to lo_server_thread_new().
  */
-typedef struct lo_server_thread_ {} *lo_server_thread;
+typedef struct lo_server_thread_ *lo_server_thread;
 
 /**
  * \brief A callback function to receive notification of an error in a server or


### PR DESCRIPTION
I have two minor things that result in issues with the VS2017 compiler, and will likely be the same with newer ones as well. In general, the CMake generated project will compile the library fine, but when the actual example C applications are built, we see errors for all the empty struct defs, such as:

[typedef struct lo_address_ {}  *lo_address;](https://github.com/radarsat1/liblo/blob/master/lo/lo_types.h#L45)

"Error C2016: C requires that a struct or union has at least one member".

This doesn't happen for .cpp files, or if you force the compiler to treat everything in C++ mode with the /Tp switch (C/C++ Project properties->Advanced->Compile As setting)

My understanding is that the empty struct definition is only valid in the GNU compiler since it supports this non-standard extension of having nothing in the {}.

For the above (and similar definitions), it looks like this is the way to define it:

```
typedef struct lo_address_  *lo_address; //OK
typedef struct lo_address_ {}  *lo_address; //Not OK in C mode, OK in C++ mode

```
The second thing is it looks like the _MSC_VER toggled typedef for [ssize_t](https://github.com/radarsat1/liblo/blob/master/lo/lo_lowlevel.h#L34) needs to `#include <BaseTsd.h>` right before it to actually compile. Doesn't raise any issues when compiling the library itself, but I noticed it when trying to compile something else that depends on it. Not sure if its better to treat this at the project settings level or just in the code here as I have done...

