### PR TITLE
Support sending messages SLIP double-ENDed

### DIFF
--- a/lo/lo_cpp.h
+++ b/lo/lo_cpp.h
@@ -307,11 +307,8 @@ namespace lo {
         int set_tcp_nodelay(int enable)
           { LO_CHECK_BEFORE; return lo_address_set_tcp_nodelay(address, enable); }
 
-        int set_stream_slip(int enable)
-          { LO_CHECK_BEFORE; return lo_address_set_stream_slip(address, enable); }
-
-        int set_stream_slip_double_end(int enable)
-          { LO_CHECK_BEFORE; return lo_address_set_stream_slip_double_end(address, enable); }
+        int set_stream_slip(lo_slip_encoding encoding)
+          { LO_CHECK_BEFORE; return lo_address_set_stream_slip(address, encoding); }
 
         operator lo_address() const
             { return address; }

--- a/lo/lo_cpp.h
+++ b/lo/lo_cpp.h
@@ -310,6 +310,9 @@ namespace lo {
         int set_stream_slip(int enable)
           { LO_CHECK_BEFORE; return lo_address_set_stream_slip(address, enable); }
 
+        int set_stream_slip_double_end(int enable)
+          { LO_CHECK_BEFORE; return lo_address_set_stream_slip_double_end(address, enable); }
+
         operator lo_address() const
             { return address; }
 

--- a/lo/lo_lowlevel.h
+++ b/lo/lo_lowlevel.h
@@ -77,6 +77,16 @@ typedef struct {
     void *err_handler_context;
 } lo_server_config;
 
+/**
+ * \brief Used with \ref lo_address_set_stream_slip() to specify whether sent
+ *        messages should be encoded with SLIP, and whether the encoding should
+ *        be single- or double-ENDed.
+ */
+typedef enum {
+	LO_SLIP_NONE   = 0,
+	LO_SLIP_SINGLE = 1,
+	LO_SLIP_DOUBLE = 2
+} lo_slip_encoding;
 
 /**
  * \brief Send a lo_message object to target targ
@@ -497,19 +507,10 @@ int lo_address_set_tcp_nodelay(lo_address t, int enable);
  * \brief Set outgoing stream connections (e.g., TCP) to be
  *        transmitted using the SLIP packetizing protocol.
  * \param t The address to set this flag for.
- * \param enable Non-zero to set the flag, zero to unset it.
+ * \param encoding Specify single- or double-ENDed SLIP, or disable SLIP.
  * \return the previous value of this flag.
  */
-int lo_address_set_stream_slip(lo_address t, int enable);
-
-/**
- * \brief Set outgoing stream connections using SLIP to be
- *        double ENDed. (No effect if SLIP isn't enabled.)
- * \param t The address to set this flag for.
- * \param enable Non-zero to set the flag, zero to unset it.
- * \return the previous value of this flag.
- */
-int lo_address_set_stream_slip_double_end(lo_address t, int enable);
+int lo_address_set_stream_slip(lo_address t, lo_slip_encoding encoding);
 
 /**
  * \brief  Create a new bundle object.

--- a/lo/lo_lowlevel.h
+++ b/lo/lo_lowlevel.h
@@ -503,6 +503,15 @@ int lo_address_set_tcp_nodelay(lo_address t, int enable);
 int lo_address_set_stream_slip(lo_address t, int enable);
 
 /**
+ * \brief Set outgoing stream connections using SLIP to be
+ *        double ENDed. (No effect if SLIP isn't enabled.)
+ * \param t The address to set this flag for.
+ * \param enable Non-zero to set the flag, zero to unset it.
+ * \return the previous value of this flag.
+ */
+int lo_address_set_stream_slip_double_end(lo_address t, int enable);
+
+/**
  * \brief  Create a new bundle object.
  *
  * OSC Bundles encapsulate one or more OSC messages and may include a timestamp

--- a/src/address.c
+++ b/src/address.c
@@ -485,19 +485,17 @@ int lo_address_set_tcp_nodelay(lo_address t, int enable)
     return r;
 }
 
-int lo_address_set_stream_slip(lo_address t, int enable)
+int lo_address_set_stream_slip(lo_address t, lo_slip_encoding encoding)
 {
-    int r = (t->flags & LO_SLIP) != 0;
-    lo_address_set_flags(t, enable
+    int r = t->flags & LO_SLIP_DBL_END
+        ? LO_SLIP_DOUBLE
+        : t->flags & LO_SLIP
+            ? LO_SLIP_SINGLE
+            : LO_SLIP_NONE;
+    lo_address_set_flags(t, encoding > 0
                          ? t->flags | LO_SLIP
                          : t->flags & ~LO_SLIP);
-    return r;
-}
-
-int lo_address_set_stream_slip_double_end(lo_address t, int enable)
-{
-    int r = (t->flags & LO_SLIP_DBL_END) != 0;
-    lo_address_set_flags(t, enable
+    lo_address_set_flags(t, encoding > 1
                          ? t->flags | LO_SLIP_DBL_END
                          : t->flags & ~LO_SLIP_DBL_END);
     return r;

--- a/src/address.c
+++ b/src/address.c
@@ -494,6 +494,15 @@ int lo_address_set_stream_slip(lo_address t, int enable)
     return r;
 }
 
+int lo_address_set_stream_slip_double_end(lo_address t, int enable)
+{
+    int r = (t->flags & LO_SLIP_DBL_END) != 0;
+    lo_address_set_flags(t, enable
+                         ? t->flags | LO_SLIP_DBL_END
+                         : t->flags & ~LO_SLIP_DBL_END);
+    return r;
+}
+
 static
 void lo_address_set_flags(lo_address t, int flags)
 {

--- a/src/liblo.def.in
+++ b/src/liblo.def.in
@@ -148,3 +148,4 @@ EXPORTS
     lo_servers_recv_noblock                @145
     lo_server_new_from_config              @146
 @DEFTHREADS@    lo_server_thread_new_from_config       @147
+    lo_address_set_stream_slip_double_end  @148

--- a/src/liblo.def.in
+++ b/src/liblo.def.in
@@ -148,4 +148,3 @@ EXPORTS
     lo_servers_recv_noblock                @145
     lo_server_new_from_config              @146
 @DEFTHREADS@    lo_server_thread_new_from_config       @147
-    lo_address_set_stream_slip_double_end  @148

--- a/src/lo_types_internal.h
+++ b/src/lo_types_internal.h
@@ -52,8 +52,9 @@ typedef SSIZE_T ssize_t;
 /** \brief Bitflags for optional protocol features, set by
  *         lo_address_set_flags(). */
 typedef enum {
-    LO_SLIP=0x01,     /*!< SLIP decoding */
-    LO_NODELAY=0x02,  /*!< Set the TCP_NODELAY socket option. */
+    LO_SLIP=0x01,         /*!< SLIP decoding */
+    LO_NODELAY=0x02,      /*!< Set the TCP_NODELAY socket option. */
+    LO_SLIP_DBL_END=0x04, /*!< Set SLIP encoding to double-END. */
 } lo_proto_flags;
 
 /** \brief Bitflags for optional server features. */

--- a/src/send.c
+++ b/src/send.c
@@ -585,7 +585,8 @@ static int send_data(lo_address a, lo_server from, char *data,
         } else {
             size_t len = data_len;
             if (a->flags & LO_SLIP)
-                data = (char*)slip_encode((unsigned char*)data, &len, a->flags & LO_SLIP_DBL_END);
+                data = (char*)slip_encode((unsigned char*)data, &len,
+                                          a->flags & LO_SLIP_DBL_END);
 
             ret = send(sock, data, len, MSG_NOSIGNAL);
 

--- a/src/send.c
+++ b/src/send.c
@@ -470,10 +470,13 @@ static int create_socket(lo_address a)
 #define SLIP_ESC_ESC    0335    /* ESC ESC_ESC means ESC data byte */
 
 static unsigned char *slip_encode(const unsigned char *data,
-                                  size_t *data_len)
+                                  size_t *data_len,
+                                  int double_end_slip_enabled)
 {
     size_t i, j = 0, len=*data_len;
     unsigned char *slipdata = (unsigned char *) malloc(len*2);
+    if (double_end_slip_enabled)
+        slipdata[j++] = SLIP_END;
     for (i=0; i<len; i++) {
         switch (data[i])
         {
@@ -582,7 +585,7 @@ static int send_data(lo_address a, lo_server from, char *data,
         } else {
             size_t len = data_len;
             if (a->flags & LO_SLIP)
-                data = (char*)slip_encode((unsigned char*)data, &len);
+                data = (char*)slip_encode((unsigned char*)data, &len, a->flags & LO_SLIP_DBL_END);
 
             ret = send(sock, data, len, MSG_NOSIGNAL);
 


### PR DESCRIPTION
Some time ago I provided a PR (#86) to support *receiving* messages sent with double-ENDed SLIP. This is the other side of things - *sending* messages as double-ENDed SLIP.

I've attempted to implement it in such a way as to be backwards compatible: it should still be possible to pass the older expected `int` values to `lo_address_set_stream_slip()` and get the same results as before. If however you'd prefer the enabling of double-END to be a separate function (e.g. `lo_address_set_stream_slip_double_end()`), then that could be achieved instead.