### PR TITLE
WIN32: detect target correctly.

### DIFF
--- a/lo/lo_endian.h.in
+++ b/lo/lo_endian.h.in
@@ -20,7 +20,7 @@
 #include <sys/types.h>
 #include <stdint.h>
 
-#if defined(WIN32) || defined(_MSC_VER)
+#if defined(_WIN32)
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #else

--- a/lo/lo_types.h
+++ b/lo/lo_types.h
@@ -25,7 +25,7 @@
 extern "C" {
 #endif
 
-#if defined(WIN32) || defined(_MSC_VER)
+#if defined(_WIN32)
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #else


### PR DESCRIPTION
When compiling the tests of RTOSC submodule of  ZynAddSubFx, I got the same error signaled into issue #114.
This happens because `WIN32` is undefined. The right symbol to use is `_WIN32` since it is intrinsic to the compiler. See:

https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?redirectedfrom=MSDN&view=msvc-170

Actually, testing for `_MSC_VER` has also no much sense here , because if `_WIN32` does not exist then you surely cannot use or include WinSock.