### PR TITLE
Fix one more "maybe uninitialized" compiler warning

### DIFF
--- a/src/tools/oscsendfile.c
+++ b/src/tools/oscsendfile.c
@@ -64,7 +64,7 @@ lo_message create_message(char **argv)
     int i, argi;
     lo_message message;
     const char *types;
-    char *arg;
+    char *arg = NULL;
     int values;
 
     message = lo_message_new();


### PR DESCRIPTION
On Fedora 36 this is causing a build failure because of -Werror=maybe-uninitialized