### PR TITLE
LO_UNIX: resolve port and return socket file path

### DIFF
--- a/src/address.c
+++ b/src/address.c
@@ -34,6 +34,7 @@
 #include <unistd.h>
 #include <netdb.h>
 #include <sys/socket.h>
+#include <sys/un.h>
 #include <arpa/inet.h>
 #include <netinet/tcp.h>
 #ifdef HAVE_GETIFADDRS
@@ -189,6 +190,10 @@ static void lo_address_resolve_source(lo_address a)
 
         a->host = strdup(hostname);
         a->port = strdup(portname);
+    } else if (a->protocol== LO_UNIX) {
+        struct sockaddr_un * addr = (struct sockaddr_un *) &s->addr;
+        a->host = strdup("");
+        a->port = strdup(addr->sun_path);
     } else {
         a->host = strdup("");
         a->port = strdup("");

--- a/src/send.c
+++ b/src/send.c
@@ -582,7 +582,7 @@ static int send_data(lo_address a, lo_server from, char *data,
             } while (ret == -1 && ai != NULL);
             if (ret == -1 && ai != NULL && a->ai!=ai)
                 a->ai = ai;
-        } else if (a->protocol == LO_UNIX && from->protocol == LO_UNIX) {
+        } else if (a->protocol == LO_UNIX && from && from->protocol == LO_UNIX) {
             struct sockaddr_un saddr;
             size_t len = data_len;
 

--- a/src/send.c
+++ b/src/send.c
@@ -582,7 +582,16 @@ static int send_data(lo_address a, lo_server from, char *data,
             } while (ret == -1 && ai != NULL);
             if (ret == -1 && ai != NULL && a->ai!=ai)
                 a->ai = ai;
+        } else if (a->protocol == LO_UNIX && from->protocol == LO_UNIX) {
+            struct sockaddr_un saddr;
+            size_t len = data_len;
+
+            saddr.sun_family = AF_UNIX;
+            strncpy(saddr.sun_path, a->port, sizeof(saddr.sun_path) - 1);
+
+            ret = sendto(from->sockets[0].fd, data, len, MSG_NOSIGNAL, (struct sockaddr*)&saddr, sizeof(struct sockaddr_un));
         } else {
+
             size_t len = data_len;
             if (a->flags & LO_SLIP)
                 data = (char*)slip_encode((unsigned char*)data, &len,


### PR DESCRIPTION
This PR fixes `lo_address_get_port` on incoming messages for the LO_UNIX protocol, it's probably not the cleanest,  but addresses issue #121.