### PR TITLE
Apple clang conversion and doxygen format warning fixes

### DIFF
--- a/src/address.c
+++ b/src/address.c
@@ -447,13 +447,13 @@ char *lo_url_get_path(const char *url)
         return path;
     }
     if (sscanf(url, "osc.unix://%*[^/]%s", path)) {
-        int i = strlen(path)-1;
+        int i = (int) strlen(path)-1;
         if (path[i]=='/') // remove trailing slash
             path[i] = 0;
         return path;
     }
     if (sscanf(url, "osc.%*[^:]://%s", path)) {
-        int i = strlen(path)-1;
+        int i = (int) strlen(path)-1;
         if (path[i]=='/') // remove trailing slash
             path[i] = 0;
         return path;
@@ -554,7 +554,7 @@ void lo_address_init_with_sockaddr(lo_address a,
     a->host = (char*) malloc(INET_ADDRSTRLEN);
     a->port = (char*) malloc(8);
 
-    err = getnameinfo((struct sockaddr *)sa, sa_len,
+    err = getnameinfo((struct sockaddr *)sa, (socklen_t) sa_len,
                       a->host, INET_ADDRSTRLEN, a->port, 8,
                       NI_NUMERICHOST | NI_NUMERICSERV);
 

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -220,7 +220,7 @@ lo_timetag lo_bundle_get_timestamp(lo_bundle b)
 
 unsigned int lo_bundle_count(lo_bundle b)
 {
-    return b->len;
+    return (unsigned int) b->len;
 }
 
 size_t lo_bundle_length(lo_bundle b)

--- a/src/lo_internal.h
+++ b/src/lo_internal.h
@@ -88,7 +88,6 @@ int lo_server_add_socket(lo_server s, int socket, lo_address a,
  *  \param s The lo_server
  *  \param index The index of the socket to delete, -1 if socket is provided.
  *  \param socket The socket number to delete, -1 if index is provided.
- *  \return The index number of the added socket.
  */
 void lo_server_del_socket(lo_server s, int index, int socket);
 

--- a/src/lo_types_internal.h
+++ b/src/lo_types_internal.h
@@ -141,8 +141,8 @@ struct socket_context {
     size_t buffer_size;
     unsigned int buffer_msg_offset;
     unsigned int buffer_read_offset;
-    int is_slip;                        //<! 1 if slip mode, 0 otherwise, -1 for unknown
-    int slip_state;                     //<! state variable for slip decoding
+    int is_slip;    /*!< 1 if slip mode, 0 otherwise, -1 for unknown */
+    int slip_state; /*!< state variable for slip decoding */
 };
 
 #ifdef HAVE_POLL

--- a/src/message.c
+++ b/src/message.c
@@ -479,7 +479,7 @@ int lo_message_add_infinitum(lo_message m)
 static int lo_message_add_typechar(lo_message m, char t)
 {
     if (m->typelen + 1 >= m->typesize) {
-        int new_typesize = m->typesize * 2;
+        int new_typesize = (int) m->typesize * 2;
         char *new_types = 0;
         if (!new_typesize)
             new_typesize = LO_DEF_TYPE_SIZE;
@@ -501,9 +501,9 @@ static int lo_message_add_typechar(lo_message m, char t)
 
 static void *lo_message_add_data(lo_message m, size_t s)
 {
-    uint32_t old_dlen = m->datalen;
-    int new_datasize = m->datasize;
-    int new_datalen = m->datalen + s;
+    uint32_t old_dlen = (uint32_t) m->datalen;
+    int new_datasize = (int) m->datasize;
+    int new_datalen = (int) (m->datalen + s);
     void *new_data = 0;
 
     if (!new_datasize)
@@ -528,7 +528,7 @@ static void *lo_message_add_data(lo_message m, size_t s)
 
 int lo_strsize(const char *s)
 {
-    return (NULL != s)? (4 * (strlen(s) / 4 + 1)) : 0;
+    return (NULL != s)? (4 * ((int) strlen(s) / 4 + 1)) : 0;
 }
 
 size_t lo_arg_size(lo_type type, void *data)
@@ -804,7 +804,7 @@ size_t lo_message_length(lo_message m, const char *path)
 
 int lo_message_get_argc(lo_message m)
 {
-    return m->typelen - 1;
+    return (int) m->typelen - 1;
 }
 
 lo_arg **lo_message_get_argv(lo_message m)
@@ -817,7 +817,7 @@ lo_arg **lo_message_get_argv(lo_message m)
         return m->argv;
     }
 
-    argc = m->typelen - 1;
+    argc = (int) m->typelen - 1;
     types = m->types + 1;
     ptr = (char*) m->data;
 
@@ -860,7 +860,7 @@ void *lo_message_serialise(lo_message m, const char *path, void *to,
     ptr = (char*) to + lo_strsize(path) + lo_strsize(m->types);
     memcpy(ptr, m->data, m->datalen);
 
-    argc = m->typelen - 1;
+    argc = (int) m->typelen - 1;
     for (i = 0; i < argc; ++i) {
         size_t len = lo_arg_size((lo_type) types[i], ptr);
         lo_arg_network_endian((lo_type) types[i], ptr);
@@ -874,7 +874,7 @@ lo_message lo_message_deserialise(void *data, size_t size, int *result)
 {
     lo_message msg = NULL;
     char *types = NULL, *ptr = NULL;
-    int i = 0, argc = 0, remain = size, res = 0, len;
+    int i = 0, argc = 0, remain = (int) size, res = 0, len;
 
     if (remain <= 0) {
         res = LO_ESIZE;
@@ -899,7 +899,7 @@ lo_message lo_message_deserialise(void *data, size_t size, int *result)
     msg->refcount = 0;
 
     // path
-    len = lo_validate_string(data, remain);
+    len = (int) lo_validate_string(data, remain);
     if (len < 0) {
         res = LO_EINVALIDPATH;  // invalid path string
         goto fail;
@@ -917,7 +917,7 @@ lo_message lo_message_deserialise(void *data, size_t size, int *result)
         goto fail;
     }
     types = (char*) data + len;
-    len = lo_validate_string(types, remain);
+    len = (int) lo_validate_string(types, remain);
     if (len < 0) {
         res = LO_EINVALIDTYPE;  // invalid type tag string
         goto fail;
@@ -949,7 +949,7 @@ lo_message lo_message_deserialise(void *data, size_t size, int *result)
     ptr = (char*) msg->data;
 
     ++types;
-    argc = msg->typelen - 1;
+    argc = (int) msg->typelen - 1;
     if (argc) {
         msg->argv = (lo_arg **) calloc(argc, sizeof(lo_arg *));
         if (NULL == msg->argv) {
@@ -959,7 +959,7 @@ lo_message lo_message_deserialise(void *data, size_t size, int *result)
     }
 
     for (i = 0; remain >= 0 && i < argc; ++i) {
-        len = lo_validate_arg((lo_type) types[i], ptr, remain);
+        len = (int) lo_validate_arg((lo_type) types[i], ptr, remain);
         if (len < 0) {
             res = LO_EINVALIDARG;       // invalid argument
             goto fail;
@@ -1025,7 +1025,7 @@ void lo_arg_pp_internal(lo_type type, void *data, int bigendian)
     int size;
     int i;
 
-    size = lo_arg_size(type, data);
+    size = (int) lo_arg_size(type, data);
     if (size == 4 || type == LO_BLOB) {
         if (bigendian) {
             val32.nl = lo_otoh32(*(int32_t *) data);

--- a/src/send.c
+++ b/src/send.c
@@ -519,7 +519,7 @@ static int send_data(lo_address a, lo_server from, char *data,
     if (!a->ai) {
         ret = lo_address_resolve(a);
         if (ret)
-            return ret;
+            return (int) ret;
     }
     // Re-use existing socket?
     if (from && a->protocol == LO_UDP) {
@@ -530,7 +530,7 @@ static int send_data(lo_address a, lo_server from, char *data,
         if (a->socket == -1) {
             ret = create_socket(a);
             if (ret)
-                return ret;
+                return (int) ret;
 
             // If we are sending TCP, we may later receive on sending
             // socket, so add it to the from server's socket list.
@@ -559,12 +559,12 @@ static int send_data(lo_address a, lo_server from, char *data,
             struct addrinfo* ai;
             if (a->addr.size == sizeof(struct in_addr)) {
                 setsockopt(sock, IPPROTO_IP, IP_MULTICAST_IF,
-                           (const char*)&a->addr.a, a->addr.size);
+                           (const char*)&a->addr.a, (socklen_t) a->addr.size);
             }
 #ifdef ENABLE_IPV6
             else if (a->addr.size == sizeof(struct in6_addr)) {
                 setsockopt(sock, IPPROTO_IP, IPV6_MULTICAST_IF,
-                           (const char*)&a->addr.a, a->addr.size);
+                           (const char*)&a->addr.a, (socklen_t) a->addr.size);
             }
 #endif
             if (a->ttl >= 0) {
@@ -610,7 +610,7 @@ static int send_data(lo_address a, lo_server from, char *data,
         a->errstr = NULL;
     }
 
-    return ret;
+    return (int) ret;
 }
 
 

--- a/src/timetag.c
+++ b/src/timetag.c
@@ -57,7 +57,7 @@ void lo_timetag_now(lo_timetag * t)
     struct timeval tv;
 
     gettimeofday(&tv, NULL);
-    t->sec = tv.tv_sec + JAN_1970;
+    t->sec = (uint32_t) (tv.tv_sec + JAN_1970);
     t->frac = tv.tv_usec * 4294.967295;
 #endif
 }


### PR DESCRIPTION
This PR fixes warnings generated by Apple's clang as used within Xcode. I'm making an Xcode project wrapper for liblo as the old method of manually compiling each arch and stitching them together to make a fat iOS + Simulator liblo.a no longer works.

Most of the warnings are about value conversions in which case I've added explicit casts. I have tried not to change any existing behavior and follow existing formatting.

There were also a couple of Doxygen-related warnings: one for an invalid inline format `//<!` and another about a `\return` on a function which returns void (copy/paste leftover).

Example clang output:
~~~
/Users/danomatika/src/PdParty/libs/liblo/src/message.c:863:23: warning: implicit conversion loses integer precision: 'unsigned long' to 'int' [-Wshorten-64-to-32]
    argc = m->typelen - 1;
         ~ ~~~~~~~~~~~^~~
/Users/danomatika/src/PdParty/libs/liblo/src/message.c:877:35: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
    int i = 0, argc = 0, remain = size, res = 0, len;
                         ~~~~~~   ^~~~
/Users/danomatika/src/PdParty/libs/liblo/src/message.c:902:11: warning: implicit conversion loses integer precision: 'ssize_t' (aka 'long') to 'int' [-Wshorten-64-to-32]
    len = lo_validate_string(data, remain);
        ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
...
/Users/danomatika/src/PdParty/libs/liblo/src/address.c:557:46: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'socklen_t' (aka 'unsigned int') [-Wshorten-64-to-32]
    err = getnameinfo((struct sockaddr *)sa, sa_len,
          ~~~~~~~~~~~                        ^~~~~~
~~~