### PR TITLE
TCP fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: install dependencies
-      run: sudo apt-get install g++-8 autoconf-archive curl zlib1g-dev
+      run: sudo apt-get install g++-9 autoconf-archive curl zlib1g-dev
     - name: autogen
       run:
         pwd

--- a/src/server.c
+++ b/src/server.c
@@ -1819,8 +1819,10 @@ void lo_server_del_socket(lo_server s, int index, int socket)
     lo_address_free_mem(&s->sources[s->sockets[index].fd]);
     cleanup_context(&s->contexts[index]);
 
-    for (i = index + 1; i < s->sockets_len; i++)
+    for (i = index + 1; i < s->sockets_len; i++) {
         s->sockets[i - 1] = s->sockets[i];
+        s->contexts[i - 1] = s->contexts[i];
+    }
     s->sockets_len--;
 }
 

--- a/src/testlo.c
+++ b/src/testlo.c
@@ -825,6 +825,7 @@ void *test_tcp_thread(void *context)
         return (void*)1;
 #endif
     }
+    lo_server_max_msg_size(s, 1024);
 
     lo_server_add_method(s, "/test", "is", test_handler, 0);
     lo_server_add_method(s, "/ok", "", ok_handler, 0);
@@ -834,7 +835,6 @@ void *test_tcp_thread(void *context)
         recv_times += 1;
         if (!lo_server_recv_noblock(s, 0))
             SLEEP_MS(300);
-        lo_server_max_msg_size(s, 1024);
     }
 
     printf("Freeing.\n");
@@ -931,6 +931,8 @@ void test_tcp_halfsend(int stream_type)
         rc = send(sock, msg+33, msglen-33, 0);
         if (rc != (msglen-33)) printf("Error sending3, rc = %d\n", rc);
         else printf("Sent3.\n");
+
+        SLEEP_MS(1000);
     }
 
     closesocket(sock);


### PR DESCRIPTION
Fixes for TCP: improved handling of disconnected/broken connections, which previously could result in infinite looping over `lo_server_recv()`. Fixed memory leak in receive buffers.