### PR TITLE
Fix "ret uninitialized" compiler warning

### DIFF
--- a/src/tools/oscsendfile.c
+++ b/src/tools/oscsendfile.c
@@ -285,7 +285,7 @@ int send_file(lo_address target, double speed) {
     char str[1024], *p, *s, *path;
     lo_timetag tt_start = {0, 0}, tt_start_file = {0, 0}, tt_now;
     lo_timetag tt1 = {0, 0}, tt2 = {0, 0}, *tt_last = &tt1, *tt_this = &tt2;
-    int tt_init = 0, ret;
+    int tt_init = 0, ret = 0;
     lo_message m;
     lo_bundle b = 0;
 


### PR DESCRIPTION
Recently I found another uninitialized variable