### PR TITLE
Fix use-after-free warning in server.c

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2289,7 +2289,6 @@ int lo_server_del_lo_method(lo_server s, lo_method m)
             free((void *) it->path);
             free((void *) it->typespec);
             free(it);
-            it = prev;
             return 0;
         }
         prev = it;


### PR DESCRIPTION
That assignment is not necessary before returning, but it's triggering (maybe a false positive) a use after free warning with gcc 13.1