### PR TITLE
WIN32: No need to use strlen() into MultiByteToWideChar()

### DIFF
--- a/src/address.c
+++ b/src/address.c
@@ -684,12 +684,12 @@ int lo_inaddr_find_iface(lo_inaddr t, int fam,
             if (strcmp(iface, aa->AdapterName)==0)
                 found = 1;
             else {
-				WCHAR ifaceW[256];
-				MultiByteToWideChar(CP_ACP, 0, iface, strlen(iface),
-									ifaceW, 256);
-				if (lstrcmpW(ifaceW, aa->FriendlyName)==0)
-					found = 1;
-			}
+                WCHAR ifaceW[256];
+                MultiByteToWideChar(CP_ACP, 0, iface, -1,
+                                    ifaceW, 256);
+                if (lstrcmpW(ifaceW, aa->FriendlyName)==0)
+                    found = 1;
+            }
         }
         if (ip) {
             PIP_ADAPTER_UNICAST_ADDRESS pua = aa->FirstUnicastAddress;


### PR DESCRIPTION
The call to strlen() can be removed because MultiByteToWideChar() already calculates its value if the parameter is -1.
See here:
https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-multibytetowidechar

![immagine](https://github.com/radarsat1/liblo/assets/30959007/35896bc7-21a8-42b3-8fb0-324085ec51c7)

Since the entire source is using spaces but this piece of code uses hardware tabs, I also adjusted this.