### PR TITLE
WIN32: WSAGetLastError() returns WSAEINVAL

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -681,7 +681,7 @@ lo_server lo_server_new_with_proto_internal(const char *group,
              0)) {
             err = geterror();
 #ifdef WIN32
-            if (err == EINVAL || err == WSAEADDRINUSE) {
+            if (err == WSAEINVAL || err == WSAEADDRINUSE) {
 #else
             if (err == EINVAL || err == EADDRINUSE) {
 #endif


### PR DESCRIPTION
`WSAGetLastError()` returns `WSAEINVAL` (10022), not `EINVAL` (22).
See also here:
https://learn.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2