### PR TITLE
WIN32: fix declaration of UINT_PTR

### DIFF
--- a/src/lo_types_internal.h
+++ b/src/lo_types_internal.h
@@ -30,7 +30,7 @@
 typedef SSIZE_T ssize_t;
 #endif
 
-#ifndef UINT_PTR
+#if !defined(UINT_PTR) && !defined(WIN32)
   #ifdef HAVE_UINTPTR_T
     #include <stdint.h>
     #define UINT_PTR uintptr_t


### PR DESCRIPTION
This code added a macro `UINT_PTR` but on W32API and MS PSDK it is declared with a typedef instead, see here:

https://github.com/mingw-w32/mingw-org-wsl/blob/5ae20fb2ea2f986ba30174feafc6842f0e98fd14/w32api/include/basetsd.h#L64 

https://github.com/mingw-w32/mingw-org-wsl/blob/5ae20fb2ea2f986ba30174feafc6842f0e98fd14/w32api/include/basetsd.h#L102

For this reason, it happened that:
1) `UINT_PTR` is always undefined because it's a typedef, when compiling for Windows on both MINGW and MSVC.
2) `HAVE_UINTPTR_T` is handled by autoconf configure script, but not by CMakeLists.txt. So, when compiling with CMake, `HAVE_UINTPTR_T` is also always undefined.

For this reasons, when compiling on 64bit for Windows, `UINT_PTR` was set to `unsigned long`, by overwriting the system type with this macro. In my opinion, the best way to avoid malfunctions and complains from MINGW and MSVC when compiling for 64bit is to not overload that system type with this macro when `WIN32` is defined.