### PR TITLE
Force static linkage while building with MSVC to fix compilation

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -49,6 +49,10 @@ if (MSVC)
     /D_CRT_NONSTDC_NO_DEPRECATE
     /D_WINSOCK_DEPRECATED_NO_WARNINGS)
 
+  # liblo fails to build as a dynamic library on MSVC
+  set(WITH_STATIC ON)
+  message(STATUS "Building as static lib as dynamic builds fail on MSVC")
+
   # On Windows we do not wish the default behaviour of removing "lib"
   # from "liblo.dll".
   if ("${CMAKE_SHARED_LIBRARY_PREFIX}" STREQUAL "")


### PR DESCRIPTION
While building liblo v 0.32 on MSVC, I had lots of LNK 2019 errors popping up. After some investigation, I found that building everything statically fixed it, though I doubt if this is the correct way. But since this fixes the issue with building, I want to make it upstream.

Also to note, I just opened a vcpkg port update for liblo here : https://github.com/microsoft/vcpkg/pull/36836