### PR TITLE
Optimize server2

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,13 @@ sockets. IPv6 is currently disabled by default, but you can enable it
 using
 
     ./configure --enable-ipv6
+
+## Poll() vs Select()
+
+Some platforms may have both `poll()` and `select()` available for listening efficiently on multiple servers/sockets. In this case, liblo will default to using `poll` since it is comsidered to be more scalable. However, on some platforms (e.g. MacOS) the liblo code path using `select()` is considerably faster so you may wish to explictly disable support for `poll` if your applications do not require extreme scalability and are sensitive to small differences in efficiency. This can be done when compiling the library from source, either using configure:
+
+    ./configure --disable-poll
+
+or if using cmake:
+
+    cmake -DWITH_POLL=OFF <path>

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -144,6 +144,9 @@ set(NONBLOCKING_SERVER_EXAMPLE_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../examples/n
 
 if (WITH_POLL)
     check_symbol_exists(poll poll.h HAVE_POLL)
+else()
+    message(STATUS "Excluding poll support.")
+    set(HAVE_POLL OFF)
 endif()
 check_symbol_exists(select sys/select.h HAVE_SELECT)
 if(NOT HAVE_POLL AND NOT HAVE_SELECT)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -6,6 +6,7 @@ option(WITH_EXAMPLES "Enable building examples." ON)
 option(WITH_CPP_TESTS "Enable building C++ wrapper tests." ON)
 option(WITH_STATIC "Enable building static library." OFF)
 option(THREADING "Build with threading support." ON)
+option(WITH_POLL "Build with poll support." ON)
 
 if (WITH_STATIC)
   message(STATUS "If you are using the static library build, please keep in mind (and inform yourself of the implications) that liblo is licensed with LGPL v2.1+.")
@@ -141,7 +142,9 @@ set(EXAMPLE_SERVER_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../examples/example_serve
 set(EXAMPLE_TCP_ECHO_SERVER_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../examples/example_tcp_echo_server.c)
 set(NONBLOCKING_SERVER_EXAMPLE_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../examples/nonblocking_server_example.c)
 
-check_symbol_exists(poll poll.h HAVE_POLL)
+if (WITH_POLL)
+    check_symbol_exists(poll poll.h HAVE_POLL)
+endif()
 check_symbol_exists(select sys/select.h HAVE_SELECT)
 if(NOT HAVE_POLL AND NOT HAVE_SELECT)
   if(CMAKE_SYSTEM_NAME MATCHES "Windows")

--- a/configure.ac
+++ b/configure.ac
@@ -210,7 +210,6 @@ AC_CHECK_FUNC([select], [AC_DEFINE(HAVE_SELECT, [1], [Define to 1 if select() is
                  AC_DEFINE(HAVE_SELECT, [1], [Define to 1 if select() is available.])
                  is_windows=yes],[AC_MSG_RESULT(no)])
 ])
-AC_CHECK_FUNC([poll], [AC_DEFINE(HAVE_POLL, [1], [Define to 1 if poll() is available.])])
 AC_CHECK_FUNC([setvbuf], [AC_DEFINE(HAVE_SETVBUF, [1], [Define to 1 if setvbuf() is available.])])
 
 AM_CONDITIONAL(WINDOWS, test x$is_windows = xyes)
@@ -259,6 +258,17 @@ AM_CONDITIONAL([COMPILE_TESTS],[test x$enable_tests != xno])
 AM_CONDITIONAL([COMPILE_TOOLS],[test x$enable_tools != xno])
 AM_CONDITIONAL([COMPILE_EXAMPLES],[test x$enable_examples != xno])
 AM_CONDITIONAL([ENABLE_NETWORK_TESTS],[test x$enable_network_tests != xno])
+
+# Check if poll is wanted
+AC_ARG_ENABLE(poll,
+  [  --disable-poll        Disable compiling with poll support],
+  [want_poll=$enableval],
+  [want_poll=yes])
+
+# Check for whether poll is wanted, and if so, did we find it.
+if test "x$want_poll" = "xyes"; then
+  AC_CHECK_FUNC([poll], [AC_DEFINE(HAVE_POLL, [1], [Define to 1 if poll() is available.])])
+fi
 
 if ! test x$enable_network_tests = xno; then
   AC_DEFINE(ENABLE_NETWORK_TESTS, [1],

--- a/lo/lo_lowlevel.h
+++ b/lo/lo_lowlevel.h
@@ -799,8 +799,9 @@ void lo_server_free(lo_server s);
  * \param timeout A timeout in milliseconds to wait for the incoming packet.
  * a value of 0 will return immediately.
  *
- * The return value is 1 if there is a message waiting or 0 if
- * there is no message. If there is a message waiting you can now
+ * The return value is 1 if there is a message waiting, 0 if
+ * there is no message, and -1 if there is an error that causes the
+ * function to return early. If there is a message waiting you can now
  * call lo_server_recv() to receive that message.
  */
 int lo_server_wait(lo_server s, int timeout);
@@ -815,7 +816,8 @@ int lo_server_wait(lo_server s, int timeout);
  * a value of 0 will return immediately.
  *
  * The return value is the number of servers with a message waiting or
- * 0 if there is no message. If there is a message waiting you can now
+ * -1 if there is an error that causes the function to return early.
+ * If there is a message waiting you can now
  * call lo_server_recv() to receive that message.
  */
 int lo_servers_wait(lo_server *s, int *status, int num_servers, int timeout);

--- a/src/lo_types_internal.h
+++ b/src/lo_types_internal.h
@@ -148,7 +148,8 @@ struct socket_context {
 #ifdef HAVE_POLL
     typedef struct pollfd lo_server_fd_type;
 #else
-    typedef struct { int fd; } lo_server_fd_type;
+    typedef struct { int fd; int revents; } lo_server_fd_type;
+    #define POLLIN 0x001
 #endif
 
 typedef struct _lo_server {

--- a/src/server.c
+++ b/src/server.c
@@ -1590,14 +1590,15 @@ again:
                 recvd[i] = dispatch_queued(s[i], 0);
                 total_bytes += recvd[i];
             }
-            else {
-                // if the received message was queued we need to keep waiting
-                lo_timetag now;
-                lo_timetag_now(&now);
-                double diff = lo_timetag_diff(now, then);
-                timeout -= (int)(diff*1000);
-                if (timeout > 0.01)
-                    goto again;
+        }
+        if (!total_bytes) {
+            // we need to keep waiting if no received or queued messages are ready for dispatch
+            lo_timetag now;
+            lo_timetag_now(&now);
+            double diff = lo_timetag_diff(now, then);
+            timeout -= (int)(diff*1000);
+            if (timeout > 2) {
+                goto again;
             }
         }
     }


### PR DESCRIPTION
Server code reorganization & consolidation, fixes some erroneous behaviour and hopefully makes future maintenance easier:

- use `lo_servers_wait` internally for all calls to `poll`/`select`, i.e. with a 0 timeout for `lo_server_recv`. This removes a bunch of duplicate code
- don't call `poll`/`select` again if we already know something was received
- return an error (-1) from `lo_server_wait` and `lo_servers_wait` if returning early due to error rather than msg received or full timeout
- do not return from `lo_server_recv` if a received message was queued for future dispatch
- if a queued message is ready for dispatch, dispatch it rather than just queuing a new message and returning

Adds a configure/cmake option for disabling `poll` if desired since testing shows a substantial performance penalty for using this code path in liblo (possibly due to the `alloca`?). On MacOS/M2 Pro, the `testspeed` test in libmapper completes in ~4.3 seconds using the liblo `poll` path and ~2.6 seconds using `select`.