### PR TITLE
Reuse msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ using
 
 ## Poll() vs Select()
 
-Some platforms may have both `poll()` and `select()` available for listening efficiently on multiple servers/sockets. In this case, liblo will default to using `poll` since it is comsidered to be more scalable. However, on some platforms (e.g. MacOS) the liblo code path using `select()` is considerably faster so you may wish to explictly disable support for `poll` if your applications do not require extreme scalability and are sensitive to small differences in efficiency. This can be done when compiling the library from source, either using configure:
+Some platforms may have both `poll()` and `select()` available for listening efficiently on multiple servers/sockets. In this case, liblo will default to using `poll` since it is considered to be more scalable. However, on some platforms (e.g. MacOS) the liblo code path using `select()` is considerably faster. You may wish to explictly disable support for `poll` if your applications do not require extreme scalability and are sensitive to small differences in efficiency. This can be done when compiling the library from source, either using configure:
 
     ./configure --disable-poll
 

--- a/lo/lo_lowlevel.h
+++ b/lo/lo_lowlevel.h
@@ -144,8 +144,8 @@ lo_message lo_message_new(void);
  *
  * Messages are reference counted. If a message is multiply referenced,
  * the message's counter should be incremented. It is automatically
- * decremented by lo_message_free lo_message_free_recursive, with
- * lo_message_free_recursive being the preferable method.
+ * decremented by `lo_message_free` or `lo_bundle_free_recursive`, with
+ * `lo_bundle_free_recursive` being the preferable method if bundles are used.
  */
 void lo_message_incref(lo_message m);
 

--- a/lo/lo_lowlevel.h
+++ b/lo/lo_lowlevel.h
@@ -150,6 +150,16 @@ lo_message lo_message_new(void);
 void lo_message_incref(lo_message m);
 
 /**
+ * \brief Subtract one from a message's reference count.
+ *
+ * Messages are reference counted. In general decrementing the counter
+ * should be handled automatically using `lo_message_free` or
+ * `lo_bundle_free_recursive`, however if necessary the counter can be
+ * decremented manually.
+ */
+int lo_message_decref(lo_message m);
+
+/**
  * \brief Create a new lo_message object by cloning an already existing one
  */
 lo_message lo_message_clone(lo_message m);
@@ -159,6 +169,11 @@ lo_message lo_message_clone(lo_message m);
  * \ref lo_message_add_int32 lo_message_add*() calls.
  */
 void lo_message_free(lo_message m);
+
+/**
+ * \brief Clear elements from a lo_message but do not free allocated memory.
+ */
+void lo_message_clear(lo_message m);
 
 /**
  * \brief Append a number of arguments to a message.

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #include "lo_types_internal.h"
+#include "lo_internal.h"
 #include "lo/lo.h"
 
 lo_bundle lo_bundle_new(lo_timetag tt)
@@ -95,11 +96,11 @@ static lo_bundle *walk_tree(lo_bundle *B, lo_bundle b, size_t *len, size_t *size
 
     res = 0;
     for (i = 0; i < b->len; i++) {
-	if (b->elmnts[i].type == LO_ELEMENT_BUNDLE) {
-	    B = walk_tree(B, b->elmnts[i].content.bundle, len, size, &res);
-	    if (res)
-		break;
-	}
+        if (b->elmnts[i].type == LO_ELEMENT_BUNDLE) {
+            B = walk_tree(B, b->elmnts[i].content.bundle, len, size, &res);
+            if (res)
+                break;
+        }
     }
 
     // pop bundle from parents list
@@ -181,8 +182,8 @@ int lo_bundle_add_message(lo_bundle b, const char *path, lo_message m)
 int lo_bundle_add_bundle(lo_bundle b, lo_bundle n)
 {
     if (!n)
-	return 0;
-    
+        return 0;
+
     return lo_bundle_add_element (b, LO_ELEMENT_BUNDLE, NULL, n);
 }
 
@@ -233,15 +234,16 @@ size_t lo_bundle_length(lo_bundle b)
     }
 
     size += b->len * 4;         /* sizes */
-    for (i = 0; i < b->len; i++)
-	switch (b->elmnts[i].type) {
-	    case LO_ELEMENT_BUNDLE:
-		size += lo_bundle_length(b->elmnts[i].content.bundle);
-		break;
-	    case LO_ELEMENT_MESSAGE:
-		size += lo_message_length(b->elmnts[i].content.message.msg, b->elmnts[i].content.message.path);
-		break;
-	}
+    for (i = 0; i < b->len; i++) {
+        switch (b->elmnts[i].type) {
+            case LO_ELEMENT_BUNDLE:
+                size += lo_bundle_length(b->elmnts[i].content.bundle);
+                break;
+            case LO_ELEMENT_MESSAGE:
+                size += lo_message_length(b->elmnts[i].content.message.msg, b->elmnts[i].content.message.path);
+                break;
+        }
+    }
 
     return size;
 }
@@ -281,25 +283,24 @@ void *lo_bundle_serialise(lo_bundle b, void *to, size_t * size)
     pos += 4;
 
     for (i = 0; i < b->len; i++) {
-	switch (b->elmnts[i].type) {
-	    case LO_ELEMENT_MESSAGE:
-		lo_message_serialise(b->elmnts[i].content.message.msg, b->elmnts[i].content.message.path, pos + 4, &skip);
-		break;
-	    case LO_ELEMENT_BUNDLE:
-		lo_bundle_serialise(b->elmnts[i].content.bundle, pos+4, &skip);
-		break;
-	}
+        switch (b->elmnts[i].type) {
+            case LO_ELEMENT_MESSAGE:
+                lo_message_serialise(b->elmnts[i].content.message.msg,
+                                     b->elmnts[i].content.message.path, pos + 4, &skip);
+                break;
+            case LO_ELEMENT_BUNDLE:
+                lo_bundle_serialise(b->elmnts[i].content.bundle, pos+4, &skip);
+                break;
+        }
 
-	bes = (int32_t *) (void *)pos;
-	*bes = lo_htoo32(skip);
-	pos += skip + 4;
+        bes = (int32_t *) (void *)pos;
+        *bes = lo_htoo32(skip);
+        pos += skip + 4;
 
-	if (pos > (char*) to + s) {
-            fprintf(stderr, "liblo: data integrity error at message %lu\n",
-                    (long unsigned int)i);
-
-	    return NULL;
-	}
+        if (pos > (char*) to + s) {
+            fprintf(stderr, "liblo: data integrity error at message %lu\n", (long unsigned int)i);
+            return NULL;
+        }
     }
     if (pos != (char*) to + s) {
         fprintf(stderr, "liblo: data integrity error\n");
@@ -345,18 +346,20 @@ void lo_bundle_free(lo_bundle b)
 static void collect_element(lo_element *elmnt)
 {
     switch (elmnt->type) {
-	case LO_ELEMENT_MESSAGE: {
-	    lo_message msg = elmnt->content.message.msg;
-		lo_message_free(msg);
-        free((char*)elmnt->content.message.path);
-	    break;
-	}
+        case LO_ELEMENT_MESSAGE: {
+            lo_message msg = elmnt->content.message.msg;
+            if (lo_message_decref(msg) <= 0)
+                lo_message_free(msg);
+            free((char*)elmnt->content.message.path);
+            break;
+        }
 
-	case LO_ELEMENT_BUNDLE: {
-	    lo_bundle bndl = elmnt->content.bundle;
-        lo_bundle_free_recursive(bndl);
-	    break;
-	}
+        case LO_ELEMENT_BUNDLE: {
+            lo_bundle bndl = elmnt->content.bundle;
+//            if (lo_bundle_decref(bndl) <= 0)
+            lo_bundle_free_recursive(bndl);
+            break;
+        }
     }
 }
 
@@ -412,18 +415,18 @@ static int *lo_bundle_pp_internal(lo_bundle b, unsigned int offset,
     offset_pp(offset, state);
     printf("bundle─┬─(%08x.%08x)\n", b->ts.sec, b->ts.frac);
     for (i = 0; i < b->len; i++) {
-	state[offset+1] = i != b->len-1 ? 0 : 1;
+        state[offset+1] = i != b->len-1 ? 0 : 1;
 
-	switch(b->elmnts[i].type) {
-	    case LO_ELEMENT_MESSAGE:
-		offset_pp(offset+1, state);
-		printf("%s ", b->elmnts[i].content.message.path);
-		lo_message_pp(b->elmnts[i].content.message.msg);
-		break;
-	    case LO_ELEMENT_BUNDLE:
-		state = lo_bundle_pp_internal(b->elmnts[i].content.bundle, offset+1, state, len);
-		break;
-	}
+        switch(b->elmnts[i].type) {
+            case LO_ELEMENT_MESSAGE:
+                offset_pp(offset+1, state);
+                printf("%s ", b->elmnts[i].content.message.path);
+                lo_message_pp(b->elmnts[i].content.message.msg);
+                break;
+            case LO_ELEMENT_BUNDLE:
+                state = lo_bundle_pp_internal(b->elmnts[i].content.bundle, offset+1, state, len);
+                break;
+        }
     }
 
     return state;

--- a/src/liblo.def.in
+++ b/src/liblo.def.in
@@ -148,3 +148,5 @@ EXPORTS
     lo_servers_recv_noblock                @145
     lo_server_new_from_config              @146
 @DEFTHREADS@    lo_server_thread_new_from_config       @147
+    lo_message_clear                       @148
+    lo_message_decref                      @149

--- a/src/send.c
+++ b/src/send.c
@@ -146,8 +146,8 @@ int lo_send_timestamped_varargs_internal(lo_address t, const char *file,
         ret = lo_send_bundle(t, b);
     }
 
-    lo_message_free(msg);
     lo_bundle_free(b);
+    lo_message_free(msg);
 
     return ret;
 }

--- a/src/subtest.c
+++ b/src/subtest.c
@@ -65,6 +65,8 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
+    lo_server_thread_free(st);
+
     return 0;
 }
 

--- a/src/testlo.c
+++ b/src/testlo.c
@@ -1620,8 +1620,8 @@ void test_bundle(lo_server_thread st, lo_address a)
     lo_message_add_string(m1, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
     lo_bundle_add_message(b, "/bundle", m1);
     lo_send_bundle(a, b);
-    lo_message_free(m1);
     lo_bundle_free(b);
+    lo_message_free(m1);
 
     lo_timetag_now(&sched);
 
@@ -1634,8 +1634,8 @@ void test_bundle(lo_server_thread st, lo_address a)
     lo_bundle_add_message(b, "/bundle", m1);
 
     lo_send_bundle(a, b);
-    lo_message_free(m1);
     lo_bundle_free(b);
+    lo_message_free(m1);
 
     lo_send_timestamped(a, sched, "/bundle", "s",
                         "lo_send_timestamped() test");

--- a/src/testlo.c
+++ b/src/testlo.c
@@ -1571,7 +1571,7 @@ void test_bundle(lo_server_thread st, lo_address a)
     lo_send_bundle(a, b);
 
     /* This should be safe for multiple copies of the same message. */
-    lo_bundle_free_messages(b);
+    lo_bundle_free_recursive(b);
 
     {
         lo_timetag t = { 1, 2 };


### PR DESCRIPTION
This PR enables clearing existing lo_messages without freeing allocated memory, so that the data structure can be reused for the next OSC message. In certain contexts this can save a lot of memory allocations!

It also resolves a memory leak when calling `lo_bundle_free()` since message paths are stored but not free'd as they are in `lo_bundle_free_recursive()`.

Finally, we make `lo_message_decref()` part of the public API to provide user control of when messages should be free'd by `lo_bundle_free_recursive()`.