### PR TITLE
server.c: fix build failure as static library

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1995,10 +1995,7 @@ static void dispatch_method(lo_server s, const char *path,
                     char *tmp;
                     char *sec;
 
-                    int tmplen = (int) strlen(it->path + len) + 1;
-                    tmp = (char*) malloc(strlen(it->path + len) + 1);
-                    strncpy(tmp, it->path + len, tmplen);
-                    tmp[tmplen-1]=0;
+                    tmp = strdup(it->path + len);
                     sec = strchr(tmp, '/');
                     if (sec)
                         *sec = '\0';


### PR DESCRIPTION
As static library strncpy() can't determine precise maximum characters because strlen() is variable, so to fix build failure let's convert 3 lines into one by using strdup() that does the same as the actual code.