### PR TITLE
Distcheck fix build with doc, fix TCP port close bug.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
       run: make && (make check || (for i in src/*.log; do echo === $i ===; cat $i; done; false)) && make install && find inst
     - name: make test
       run: make test
-    - name: make dist
-      run: make dist
+    - name: make distcheck
+      run: make distcheck
     - uses: actions/upload-artifact@v4
       with:
         name: tarball

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: install dependencies
-      run: sudo apt-get install g++-9 autoconf-archive curl zlib1g-dev
+      run: sudo apt-get install g++-9 autoconf-archive curl zlib1g-dev doxygen
     - name: autogen
       run:
         pwd
@@ -41,7 +41,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: install dependencies
-      run: brew install autoconf-archive automake
+      run: brew install autoconf-archive automake doxygen
     - name: liblo autogen arm64
       run:
         pwd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         && env NOCONFIGURE=1 am_opt=--copy ./autogen.sh
         && (./configure --enable-static --prefix=$PWD/inst || (cat config.log; false))
     - name: make
-      run: make && (make check || (for i in src/*.log; do echo === $i ===; cat $i; done; false)) && make install && find inst
+      run: make
     - name: make test
       run: make test
     - name: make distcheck

--- a/configure.ac
+++ b/configure.ac
@@ -53,8 +53,20 @@ AC_PROG_CC
 AC_LIBTOOL_WIN32_DLL
 AM_PROG_LIBTOOL
 AM_PROG_CC_C_O
-AC_CHECK_PROG([DOXYGEN], [doxygen], [doc], [])
+
+# Allow documentation to be disabled, otherwise check for doxygen
+AC_ARG_ENABLE([doc],
+  [AS_HELP_STRING([--disable-doc], [Disable building documentation])],
+  [enable_doc=$enableval], [enable_doc=yes])
+
+if test "x$enable_doc" = xyes; then
+  AC_CHECK_PROG([DOXYGEN], [doxygen], [doc], [])
+  test "x$DOXYGEN" = x && AC_MSG_ERROR([doxygen not found, use --disable-doc to skip documentation])
+else
+  DOXYGEN=""
+fi
 AC_SUBST(DOXYGEN)
+AM_CONDITIONAL([ENABLE_DOC], [test "x$enable_doc" = xyes])
 
 # If we can add -Qunused-arguments, add it.
 # This error occurs when ccache and clang are used together.
@@ -300,7 +312,7 @@ else
   test x$have_threads = xyes && test x$with_win32_threads = xyes && echo '== Compile with Win32 threading'
 fi
 test x$HAVE_LAMBDA = xyes && echo '== Compiling C++ bindings' || echo '== Not compiling C++ bindings'
-test x$DOXYGEN = x && echo '== Disabled documentation (no doxygen found)'
+test x$enable_doc = xno && echo '== Disabled documentation (--disable-doc)'
 echo
 
 AC_CONFIG_FILES([

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -15,11 +15,17 @@ DOC_DIR=$(HTML_DIR)
 
 all-local: doxygen-build.stamp
 
+if ENABLE_DOC
 doxygen-build.stamp: $(DOX) ../lo/lo.h ../lo/lo_types.h ../lo/lo_lowlevel.h \
 	../lo/lo_osc_types.h
 	@echo '*** Running doxygen ***'
 	doxygen $(DOX)
 	touch doxygen-build.stamp
+else
+dist-hook:
+	@echo "ERROR: Documentation is disabled (--disable-doc), cannot make dist."
+	@false
+endif
 
 clean-local:
 	rm -f *~ *.bak $(DOC_STAMPS) || true


### PR DESCRIPTION
This commit:

* Adds an explicit option to disable docs, error if "make dist" is performed without docs, to avoid building tarballs with missing files. 
* Fixes a bug when TCP port is closed.
* Fixes hanging issue in `test_bidirectional_tcp`

Addresses #171, and maybe we can close #151 after this merge.
