### PR TITLE
Ensure lo_server_recv keeps looping until valid message is dispatched

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1626,7 +1626,7 @@ int lo_server_recv(lo_server s)
         if (ret > 0) {
             // new messages might be queued for future dispatch,
             // in which case any queued msgs that are ready should take precedence
-            if (recvd && (ret = lo_server_recv_internal(s))) {
+            if (recvd && (ret = lo_server_recv_internal(s)) > 0) {
                 // new message was received and dispatched
                 return ret;
             } else if (queued) {


### PR DESCRIPTION
This PR includes 2 fixes:

1. after a socket was removed due to POLLERR or POLLHUP, the revents for the next socket were being cleared, since after `lo_server_del_socket()` is called the socket index `i` now refers to the next socket (if it exists). Socket memory is not reallocated here so no memory-access error occured.
2. Partial receipt of a message when using TCP was causing `lo_server_recv()` to return early, even though no message had been dispatched. This PR ensured that `lo_server_recv()` keeps looping in this case.