### PR TITLE
Fixed typo in liblo.def

### DIFF
--- a/src/liblo.def.in
+++ b/src/liblo.def.in
@@ -151,4 +151,4 @@ EXPORTS
     lo_message_clear                       @148
     lo_message_decref                      @149
     lo_bundle_clear                        @150
-    lo_bundle_get_timestamp                @151
+    lo_bundle_set_timestamp                @151

--- a/src/testlo.c
+++ b/src/testlo.c
@@ -1582,6 +1582,12 @@ void test_bundle(lo_server_thread st, lo_address a)
     lo_bundle_add_message(b, "/bundle", m1);
     TEST(lo_bundle_count(b) == 1);
 
+    TEST(lo_timetag_diff(lo_bundle_get_timestamp(b), t) == 0);
+    t.sec -= 1;
+    TEST(lo_timetag_diff(lo_bundle_get_timestamp(b), t) == 1);
+    lo_bundle_set_timestamp(b, t);
+    TEST(lo_timetag_diff(lo_bundle_get_timestamp(b), t) == 0);
+
     lo_message_incref(m1);
 
     /* This should be safe for multiple copies of the same message. */


### PR DESCRIPTION
Fixed typo in liblo.def: second instance of lo_bundle_get_timestamp was supposed to be lo_bundle_set_timestamp; added call this function in testlo.c.

Typo introduced by me (sorry!) in 006ee4b